### PR TITLE
Add Lolin C3 Mini board

### DIFF
--- a/boards/lolin-c3-mini.yml
+++ b/boards/lolin-c3-mini.yml
@@ -1,0 +1,13 @@
+substitutions:
+  friendly_name: "ESP32 Tesla BLE"
+  devicename: "esp32-tesla-ble"
+  device_description: "ESP32"
+
+esp32:
+  board: lolin_c3_mini
+  flash_size: 4MB
+  variant: esp32c3
+  framework:
+    type: esp-idf
+    version: 5.2.2
+    platform_version: 6.7.0

--- a/boards/lolin-c3-mini.yml
+++ b/boards/lolin-c3-mini.yml
@@ -1,7 +1,7 @@
 substitutions:
-  friendly_name: "ESP32 Tesla BLE"
-  devicename: "esp32-tesla-ble"
-  device_description: "ESP32"
+  friendly_name: "LolinC3 Tesla BLE"
+  devicename: "lolinc3-tesla-ble"
+  device_description: "Lolin C3 Mini"
 
 esp32:
   board: lolin_c3_mini


### PR DESCRIPTION
I have successfully deployed this library onto a Lolin C3 Mini V1, so adding its board configuration.