### PR TITLE
separate init private key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,6 @@ jobs:
         run: |
           esphome_version=$(grep esphome requirements.txt | cut -d'=' -f3)
           echo "esphome_version=$esphome_version" >> "$GITHUB_OUTPUT"
-      - name: Modify packages/*.yaml to use local components
-        run: |
-          sed -i.bak 's|source: github://yoziru/esphome-tesla-ble/components@main|source: components|' packages/client.yml && rm packages/client.yml.bak
-          sed -i.bak 's|source: github://yoziru/esphome-tesla-ble/components@main|source: components|' packages/listener.yml && rm packages/listener.yml.bak
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v3.2.0
         with:

--- a/components/tesla_ble_vehicle/__init__.py
+++ b/components/tesla_ble_vehicle/__init__.py
@@ -1,19 +1,21 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import ble_client, binary_sensor
-from esphome.const import (
-    CONF_ID,
-)
+from esphome.const import CONF_ID
 
 CODEOWNERS = ["@yoziru"]
 DEPENDENCIES = ["ble_client"]
 
 tesla_ble_vehicle_ns = cg.esphome_ns.namespace("tesla_ble_vehicle")
-TeslaBLEVehicle = tesla_ble_vehicle_ns.class_("TeslaBLEVehicle", cg.PollingComponent, ble_client.BLEClientNode)
+TeslaBLEVehicle = tesla_ble_vehicle_ns.class_(
+    "TeslaBLEVehicle", cg.PollingComponent, ble_client.BLEClientNode
+)
 
-AUTO_LOAD = ['binary_sensor']
+AUTO_LOAD = ["binary_sensor"]
 CONF_VIN = "vin"
-CONF_ASLEEP = "asleep"
+CONF_IS_ASLEEP = "is_asleep"
+CONF_IS_UNLOCKED = "is_unlocked"
+CONF_IS_USER_PRESENT = "is_user_present"
 
 CONFIG_SCHEMA = (
     cv.Schema(
@@ -21,12 +23,21 @@ CONFIG_SCHEMA = (
             cv.GenerateID(CONF_ID): cv.declare_id(TeslaBLEVehicle),
             # add support to set VIN (required)
             cv.Required(CONF_VIN): cv.string,
-            cv.Optional(CONF_ASLEEP): binary_sensor.binary_sensor_schema(icon="mdi:sleep").extend(),
+            cv.Optional(CONF_IS_ASLEEP): binary_sensor.binary_sensor_schema(
+                icon="mdi:sleep"
+            ).extend(),
+            cv.Optional(CONF_IS_UNLOCKED): binary_sensor.binary_sensor_schema(
+                device_class=binary_sensor.DEVICE_CLASS_LOCK,
+            ).extend(),
+            cv.Optional(CONF_IS_USER_PRESENT): binary_sensor.binary_sensor_schema(
+                icon="mdi:account-check", device_class=binary_sensor.DEVICE_CLASS_OCCUPANCY
+            ).extend(),
         }
     )
     .extend(cv.polling_component_schema("1min"))
     .extend(ble_client.BLE_CLIENT_SCHEMA)
 )
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
@@ -36,7 +47,17 @@ async def to_code(config):
 
     cg.add(var.set_vin(config[CONF_VIN]))
 
-    if CONF_ASLEEP in config:
-        conf = config[CONF_ASLEEP]
+    if CONF_IS_ASLEEP in config:
+        conf = config[CONF_IS_ASLEEP]
         bs = await binary_sensor.new_binary_sensor(conf)
-        cg.add(var.set_binary_sensor_asleep(bs))
+        cg.add(var.set_binary_sensor_is_asleep(bs))
+
+    if CONF_IS_UNLOCKED in config:
+        conf = config[CONF_IS_UNLOCKED]
+        bs = await binary_sensor.new_binary_sensor(conf)
+        cg.add(var.set_binary_sensor_is_unlocked(bs))
+
+    if CONF_IS_USER_PRESENT in config:
+        conf = config[CONF_IS_USER_PRESENT]
+        bs = await binary_sensor.new_binary_sensor(conf)
+        cg.add(var.set_binary_sensor_is_user_present(bs))

--- a/components/tesla_ble_vehicle/custom_binary_sensor.h
+++ b/components/tesla_ble_vehicle/custom_binary_sensor.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "esphome/components/binary_sensor/binary_sensor.h"
+
+// https://github.com/esphome/feature-requests/issues/2324
+namespace esphome
+{
+    namespace binary_sensor
+    {
+
+        class CustomBinarySensor : public BinarySensor
+        {
+        public:
+            void set_has_state(bool has_state)
+            {
+                this->has_state_ = has_state;
+                // this->state = NAN;
+                this->state_callback_.call(this->state);
+            }
+        };
+
+    } // namespace binary_sensor
+} // namespace esphome

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -702,6 +702,25 @@ namespace esphome
       return 0;
     }
 
+    int TeslaBLEVehicle::handleVCSECVehicleStatus(VCSEC_VehicleStatus vehicleStatus)
+    {
+      log_vehicle_status(TAG, &vehicleStatus);
+      switch (vehicleStatus.vehicleSleepStatus)
+      {
+      case VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_AWAKE:
+        this->updateAsleepState(false);
+        break;
+      case VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_ASLEEP:
+        this->updateAsleepState(true);
+        break;
+      case VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_UNKNOWN:
+      default:
+        this->updateAsleepState(NAN);
+        break;
+      }
+      return 0;
+    }
+
     void TeslaBLEVehicle::gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                               esp_ble_gattc_cb_param_t *param)
     {
@@ -1064,20 +1083,7 @@ namespace esphome
             case VCSEC_FromVCSECMessage_vehicleStatus_tag:
             {
               ESP_LOGD(TAG, "Received vehicle status");
-              log_vehicle_status(TAG, &vcsec_message.sub_message.vehicleStatus);
-              switch (vcsec_message.sub_message.vehicleStatus.vehicleSleepStatus)
-              {
-              case VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_AWAKE:
-                this->updateAsleepState(false);
-                break;
-              case VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_ASLEEP:
-                this->updateAsleepState(true);
-                break;
-              case VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_UNKNOWN:
-              default:
-                this->updateAsleepState(NAN);
-                break;
-              }
+              handleVCSECVehicleStatus(vcsec_message.sub_message.vehicleStatus);
               break;
             }
             case VCSEC_FromVCSECMessage_commandStatus_tag:

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -55,7 +55,7 @@ namespace esphome
             int handleSessionInfoUpdate(UniversalMessage_RoutableMessage message, UniversalMessage_Domain domain);
             int nvs_save_session_info(Signatures_SessionInfo *session_info, UniversalMessage_Domain domain);
             int nvs_load_session_info(Signatures_SessionInfo *session_info, UniversalMessage_Domain domain);
-
+            int nvs_initialize_private_key();
 
             int wakeVehicle(void);
             int sendCommand(VCSEC_RKEAction_E action);

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -72,13 +72,40 @@ namespace esphome
                          esp_gatt_write_type_t write_type, esp_gatt_auth_req_t auth_req);
 
             // sensors
-            void set_binary_sensor_asleep(binary_sensor::BinarySensor *s) { asleepSensor = s; }
-            void updateAsleepState(bool asleep)
+            // Sleep state (vehicleSleepStatus)
+            void set_binary_sensor_is_asleep(binary_sensor::BinarySensor *s) { isAsleepSensor = s; }
+            void updateIsAsleep(bool asleep)
             {
-                if (asleepSensor != nullptr)
+                if (isAsleepSensor != nullptr)
                 {
-                    asleepSensor->publish_state(asleep);
+                    isAsleepSensor->publish_state(asleep);
                 }
+            }
+            // Door lock (vehicleLockState)
+            void set_binary_sensor_is_unlocked(binary_sensor::BinarySensor *s) { isUnlockedSensor = s; }
+            void updateisUnlocked(bool locked)
+            {
+                if (isUnlockedSensor != nullptr)
+                {
+                    isUnlockedSensor->publish_state(locked);
+                }
+            }
+            // User presence (userPresence)
+            void set_binary_sensor_is_user_present(binary_sensor::BinarySensor *s) { isUserPresentSensor = s; }
+            void updateIsUserPresent(bool present)
+            {
+                if (isUserPresentSensor != nullptr)
+                {
+                    isUserPresentSensor->publish_state(present);
+                }
+            }
+
+            // set sensors to unknown (e.g. when vehicle is disconnected)
+            void setSensorsUnknown()
+            {
+                updateIsAsleep(NAN);
+                updateisUnlocked(NAN);
+                updateIsUserPresent(NAN);
             }
 
         protected:
@@ -92,7 +119,11 @@ namespace esphome
             espbt::ESPBTUUID service_uuid_;
             espbt::ESPBTUUID read_uuid_;
             espbt::ESPBTUUID write_uuid_;
-            binary_sensor::BinarySensor *asleepSensor;
+
+            // sensors
+            binary_sensor::BinarySensor *isAsleepSensor;
+            binary_sensor::BinarySensor *isUnlockedSensor;
+            binary_sensor::BinarySensor *isUserPresentSensor;
 
             std::vector<unsigned char> read_buffer;
             size_t current_size = 0;

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -47,12 +47,11 @@ namespace esphome
             void gattc_event_handler(esp_gattc_cb_event_t event, esp_gatt_if_t gattc_if,
                                      esp_ble_gattc_cb_param_t *param) override;
             void dump_config() override;
-            void init();
             void set_vin(const char *vin);
 
             void regenerateKey();
             int startPair(void);
-            int nvs_save_session_info(Signatures_SessionInfo *session_info, UniversalMessage_Domain domain);
+            int nvs_save_session_info(const Signatures_SessionInfo *session_info, UniversalMessage_Domain domain);
             int nvs_load_session_info(Signatures_SessionInfo *session_info, UniversalMessage_Domain domain);
             int nvs_initialize_private_key();
 
@@ -80,6 +79,7 @@ namespace esphome
                     asleepSensor->publish_state(asleep);
                 }
             }
+            void loadSessionInfo();
 
         protected:
             TeslaBLE::Client *tesla_ble_client_;
@@ -96,6 +96,11 @@ namespace esphome
 
             std::vector<unsigned char> read_buffer;
             size_t current_size = 0;
+
+            void initializeFlash();
+            void openNVSHandle();
+            void initializePrivateKey();
+            void loadDomainSessionInfo(UniversalMessage_Domain domain);
         };
 
     } // namespace tesla_ble_vehicle

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -51,8 +51,8 @@ namespace esphome
 
             void regenerateKey();
             int startPair(void);
-            int nvs_save_session_info(const Signatures_SessionInfo *session_info, UniversalMessage_Domain domain);
-            int nvs_load_session_info(Signatures_SessionInfo *session_info, UniversalMessage_Domain domain);
+            int nvs_save_session_info(const Signatures_SessionInfo &session_info, const UniversalMessage_Domain domain);
+            int nvs_load_session_info(Signatures_SessionInfo *session_info, const UniversalMessage_Domain domain);
             int nvs_initialize_private_key();
 
             int handleSessionInfoUpdate(UniversalMessage_RoutableMessage message, UniversalMessage_Domain domain);
@@ -71,6 +71,7 @@ namespace esphome
             int writeBLE(const unsigned char *message_buffer, size_t message_length,
                          esp_gatt_write_type_t write_type, esp_gatt_auth_req_t auth_req);
 
+            // sensors
             void set_binary_sensor_asleep(binary_sensor::BinarySensor *s) { asleepSensor = s; }
             void updateAsleepState(bool asleep)
             {
@@ -79,7 +80,6 @@ namespace esphome
                     asleepSensor->publish_state(asleep);
                 }
             }
-            void loadSessionInfo();
 
         protected:
             TeslaBLE::Client *tesla_ble_client_;
@@ -100,6 +100,7 @@ namespace esphome
             void initializeFlash();
             void openNVSHandle();
             void initializePrivateKey();
+            void loadSessionInfo();
             void loadDomainSessionInfo(UniversalMessage_Domain domain);
         };
 

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -17,6 +17,8 @@
 #include <universal_message.pb.h>
 #include <vcsec.pb.h>
 
+#include "custom_binary_sensor.h"
+
 namespace TeslaBLE
 {
     class Client;
@@ -73,39 +75,30 @@ namespace esphome
 
             // sensors
             // Sleep state (vehicleSleepStatus)
-            void set_binary_sensor_is_asleep(binary_sensor::BinarySensor *s) { isAsleepSensor = s; }
+            void set_binary_sensor_is_asleep(binary_sensor::BinarySensor *s) { isAsleepSensor = static_cast<binary_sensor::CustomBinarySensor *>(s); }
             void updateIsAsleep(bool asleep)
             {
-                if (isAsleepSensor != nullptr)
-                {
-                    isAsleepSensor->publish_state(asleep);
-                }
+                isAsleepSensor->publish_state(asleep);
             }
             // Door lock (vehicleLockState)
-            void set_binary_sensor_is_unlocked(binary_sensor::BinarySensor *s) { isUnlockedSensor = s; }
+            void set_binary_sensor_is_unlocked(binary_sensor::BinarySensor *s) { isUnlockedSensor = static_cast<binary_sensor::CustomBinarySensor *>(s); }
             void updateisUnlocked(bool locked)
             {
-                if (isUnlockedSensor != nullptr)
-                {
-                    isUnlockedSensor->publish_state(locked);
-                }
+                isUnlockedSensor->publish_state(locked);
             }
             // User presence (userPresence)
-            void set_binary_sensor_is_user_present(binary_sensor::BinarySensor *s) { isUserPresentSensor = s; }
+            void set_binary_sensor_is_user_present(binary_sensor::BinarySensor *s) { isUserPresentSensor = static_cast<binary_sensor::CustomBinarySensor *>(s); }
             void updateIsUserPresent(bool present)
             {
-                if (isUserPresentSensor != nullptr)
-                {
-                    isUserPresentSensor->publish_state(present);
-                }
+                isUserPresentSensor->publish_state(present);
             }
 
             // set sensors to unknown (e.g. when vehicle is disconnected)
-            void setSensorsUnknown()
+            void setSensors(bool has_state)
             {
-                updateIsAsleep(NAN);
-                updateisUnlocked(NAN);
-                updateIsUserPresent(NAN);
+                isAsleepSensor->set_has_state(has_state);
+                isUnlockedSensor->set_has_state(has_state);
+                isUserPresentSensor->set_has_state(has_state);
             }
 
         protected:
@@ -121,9 +114,9 @@ namespace esphome
             espbt::ESPBTUUID write_uuid_;
 
             // sensors
-            binary_sensor::BinarySensor *isAsleepSensor;
-            binary_sensor::BinarySensor *isUnlockedSensor;
-            binary_sensor::BinarySensor *isUserPresentSensor;
+            binary_sensor::CustomBinarySensor *isAsleepSensor;
+            binary_sensor::CustomBinarySensor *isUnlockedSensor;
+            binary_sensor::CustomBinarySensor *isUserPresentSensor;
 
             std::vector<unsigned char> read_buffer;
             size_t current_size = 0;

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -52,10 +52,12 @@ namespace esphome
 
             void regenerateKey();
             int startPair(void);
-            int handleSessionInfoUpdate(UniversalMessage_RoutableMessage message, UniversalMessage_Domain domain);
             int nvs_save_session_info(Signatures_SessionInfo *session_info, UniversalMessage_Domain domain);
             int nvs_load_session_info(Signatures_SessionInfo *session_info, UniversalMessage_Domain domain);
             int nvs_initialize_private_key();
+
+            int handleSessionInfoUpdate(UniversalMessage_RoutableMessage message, UniversalMessage_Domain domain);
+            int handleVCSECVehicleStatus(VCSEC_VehicleStatus vehicleStatus);
 
             int wakeVehicle(void);
             int sendCommand(VCSEC_RKEAction_E action);

--- a/packages/client.yml
+++ b/packages/client.yml
@@ -29,7 +29,7 @@ button:
   - platform: template
     id: ble_pair
     name: Pair BLE key
-    icon: mdi:bluetooth-connect
+    icon: mdi:key-wireless
     on_press:
       - lambda: id(tesla_ble_vehicle_id)->startPair();
 
@@ -41,6 +41,7 @@ button:
 
   - platform: template
     name: Regenerate key
+    icon: mdi:key-change
     on_press:
       - lambda: id(tesla_ble_vehicle_id)->regenerateKey();
     entity_category: diagnostic

--- a/packages/client.yml
+++ b/packages/client.yml
@@ -65,6 +65,7 @@ switch:
   - platform: template
     name: "Charger switch"
     optimistic: true
+    restore_mode: RESTORE_DEFAULT_OFF
     turn_on_action:
       - lambda: id(tesla_ble_vehicle_id)->setChargingSwitch(true);
     turn_off_action:
@@ -85,6 +86,7 @@ number:
     max_value: 32
     step: 1
     optimistic: true
+    restore_value: true
     on_value:
       then:
         - lambda: |-
@@ -99,6 +101,7 @@ number:
     max_value: 100
     step: 1
     optimistic: true
+    restore_value: true
     on_value:
       then:
         - lambda: |-

--- a/packages/client.yml
+++ b/packages/client.yml
@@ -1,8 +1,6 @@
 external_components:
   - components: [ tesla_ble_vehicle ]
-    # uncomment for local dev
-    # source: components
-    source: github://yoziru/esphome-tesla-ble/components@main
+    source: components
 
 ble_client:
   - mac_address: !secret ble_mac_address

--- a/packages/client.yml
+++ b/packages/client.yml
@@ -13,8 +13,12 @@ tesla_ble_vehicle:
   id: tesla_ble_vehicle_id
   vin: !secret tesla_vin
   update_interval: 1min # default
-  asleep:
+  is_asleep:
     name: "Asleep"
+  is_user_present:
+    name: "User presence"
+  is_unlocked:
+    name: "Doors"
 
 button:
   - platform: restart

--- a/packages/client.yml
+++ b/packages/client.yml
@@ -70,6 +70,11 @@ switch:
     turn_off_action:
       - lambda: id(tesla_ble_vehicle_id)->setChargingSwitch(false);
 
+  - platform: ble_client
+    ble_client_id: ble_tesla_id
+    name: "BLE Connection"
+    entity_category: diagnostic
+
 number:
   - platform: template
     name: "Charging amps"

--- a/packages/client.yml
+++ b/packages/client.yml
@@ -43,19 +43,8 @@ button:
     disabled_by_default: true
 
   - platform: template
-    name: Request VCSEC
-    on_press:
-      - lambda: id(tesla_ble_vehicle_id)->sendSessionInfoRequest(UniversalMessage_Domain_DOMAIN_VEHICLE_SECURITY);
-    entity_category: diagnostic
-
-  - platform: template
-    name: Request INFOTAINMENT
-    on_press:
-      - lambda: id(tesla_ble_vehicle_id)->sendSessionInfoRequest(UniversalMessage_Domain_DOMAIN_INFOTAINMENT);
-    entity_category: diagnostic
-
-  - platform: template
-    name: Request VCSEC InfoStatus
+    name: Force data update
+    icon: mdi:database-sync
     on_press:
       - lambda: id(tesla_ble_vehicle_id)->sendInfoStatus();
     entity_category: diagnostic

--- a/packages/listener.yml
+++ b/packages/listener.yml
@@ -1,8 +1,6 @@
 external_components:
   - components: [ tesla_ble_listener ]
-    # uncomment for local dev
-    # source: components
-    source: github://yoziru/esphome-tesla-ble/components@main
+    source: components
 
 # Enable this to scan for BLE devices
 tesla_ble_listener:


### PR DESCRIPTION
- **move init pkey to nvs_initialize_private_key**
- **separate handleVCSECStatusUpdate**
- **buttons: rename InfoStatus + remove debug buttons**
- **clean up init / setup methods**
- **fix nvs load/save session info decoding**
- **add user presence + vehicle lock state sensors**
- **add BLE connection switch**
- **HA controls: restore values on restart**
- **fix binary sensors no undefined state on disconnect**
- **HA controls: update key icons**
- **Revert "fix external_components github source for esphome dashboard"**
