### PR TITLE
change key role from OWNER to DRIVER

### DIFF
--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -1043,7 +1043,7 @@ namespace esphome
       // support for wake command will be added to ROLE_CHARGING_MANAGER in a future vehicle firmware update
       // https://github.com/teslamotors/vehicle-command/issues/232#issuecomment-2181503570
       // TODO: change back to ROLE_CHARGING_MANAGER when it's supported
-      int return_code = tesla_ble_client_->buildWhiteListMessage(Keys_Role_ROLE_OWNER, VCSEC_KeyFormFactor_KEY_FORM_FACTOR_CLOUD_KEY, whitelist_message_buffer, &whitelist_message_length);
+      int return_code = tesla_ble_client_->buildWhiteListMessage(Keys_Role_ROLE_DRIVER, VCSEC_KeyFormFactor_KEY_FORM_FACTOR_CLOUD_KEY, whitelist_message_buffer, &whitelist_message_length);
       if (return_code != 0)
       {
         ESP_LOGE(TAG, "Failed to build whitelist message");


### PR DESCRIPTION
From the protocol docs:
> A **Driver** has access to most commands but cannot manage other users' keys or
otherwise configure access controls, such as changing vehicle PINs.

Seems a bit safer to use until CHARGING_MANAGER has wake support
