### PR TITLE
Update CI workflow to use newer action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   pull_request:
 
-
 jobs:
   ci:
     name: Building ${{ matrix.file }}
@@ -16,7 +15,7 @@ jobs:
           - tesla-ble-m5stack-atoms3.yml
           - tesla-ble-m5stack-nanoc6.yml
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.3.0
       - name: Mock secrets.yaml from example
         run: cp secrets.yaml.example secrets.yaml
       - name: Get ESPHome version
@@ -26,7 +25,7 @@ jobs:
           esphome_version=$(grep esphome requirements.txt | cut -d'=' -f3)
           echo "esphome_version=$esphome_version" >> "$GITHUB_OUTPUT"
       - name: Build ESPHome firmware to verify configuration
-        uses: esphome/build-action@v3.2.0
+        uses: esphome/build-action@v7.0.0
         with:
           yaml_file: ${{ matrix.file }}
           cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,5 @@ jobs:
       - name: Build ESPHome firmware to verify configuration
         uses: esphome/build-action@v7.0.0
         with:
-          yaml_file: ${{ matrix.file }}
-          cache: true
+          yaml-file: ${{ matrix.file }}
           version: ${{ steps.get_esphome_version.outputs.esphome_version }}


### PR DESCRIPTION
- Bump actions/checkout from v4.1.7 to v4.3.0
- Upgrade esphome/build-action from v3.2.0 to v7.0.0
