### PR TITLE
bump tesla-ble to 5.0.4

### DIFF
--- a/packages/board.yml
+++ b/packages/board.yml
@@ -7,4 +7,4 @@ esp32:
     components:
       - name: tesla-ble
         source: https://github.com/yoziru/tesla-ble.git
-        ref: v5.0.3
+        ref: v5.0.4


### PR DESCRIPTION
Includes stale connection fixes
- fix(peer): use steady_clock for message expiry
- fix(vehicle): reset session on ERROR_TIME_EXPIRED
- fix(client): store command request UUID
