### PR TITLE
fix: clamp charging amps in set_charging_amps, not in Number traits

### DIFF
--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -260,6 +260,8 @@ void TeslaBLEVehicle::set_charging_amps_max(int amps_max) {
     return;
   }
 
+  configured_charging_amps_max_ = amps_max;
+
   if (state_manager_) {
     state_manager_->set_charging_amps_max(amps_max);
   }
@@ -510,7 +512,7 @@ int TeslaBLEVehicle::set_charging_amps(int amps) {
 
   if (amps < 0) {
     ESP_LOGW(TAG, "Invalid charging amps: %d", amps);
-    return -1;
+    return 0;
   }
 
   int max_amps = state_manager_->get_charging_amps_max();
@@ -525,11 +527,11 @@ int TeslaBLEVehicle::set_charging_amps(int amps) {
 
   if (!vehicle_) {
     ESP_LOGE(TAG, "Vehicle instance not available");
-    return -1;
+    return amps;
   }
 
   vehicle_->set_charging_amps(amps);
-  return 0;
+  return amps;
 }
 
 int TeslaBLEVehicle::set_charging_limit(int limit) {
@@ -727,15 +729,6 @@ void TeslaBLEVehicle::close_windows() {
     vehicle_->close_windows();
 }
 
-void TeslaBLEVehicle::update_charging_amps_max_value(int32_t new_max) {
-  if (pending_charging_amps_number_) {
-    auto *tesla_amps =
-        static_cast<TeslaChargingAmpsNumber *>(pending_charging_amps_number_);
-    tesla_amps->update_max_value(new_max);
-    ESP_LOGD(TAG, "Updated charging amps max value to %d A", new_max);
-  }
-}
-
 // =============================================================================
 // BLE event handling
 // =============================================================================
@@ -834,8 +827,11 @@ void TeslaBLEVehicle::handle_connection_established() {
     last_infotainment_poll_ = millis();
   }
 
-  if (state_manager_)
+  // Reset charging amps max to configured value on each connection
+  if (state_manager_) {
+    state_manager_->set_charging_amps_max(configured_charging_amps_max_);
     state_manager_->set_sensors_available(true);
+  }
   this->status_clear_warning();
 }
 
@@ -869,29 +865,8 @@ void TeslaChargingAmpsNumber::control(float value) {
     return;
   }
 
-  parent_->set_charging_amps(static_cast<int>(value));
-  publish_state(value);
-}
-
-void TeslaChargingAmpsNumber::update_max_value(int32_t new_max) {
-  if (new_max <= 0)
-    return;
-
-  auto old_max = this->traits.get_max_value();
-
-  if (std::abs(old_max - new_max) > 0.1f) {
-    ESP_LOGD(TAG, "Updating charging amps max from %.0f to %d A", old_max,
-             new_max);
-    this->traits.set_max_value(new_max);
-
-    if (this->has_state() && this->state > new_max) {
-      this->publish_state(new_max);
-    }
-
-    if (this->has_state()) {
-      this->publish_state(this->state);
-    }
-  }
+  int clamped = parent_->set_charging_amps(static_cast<int>(value));
+  publish_state(static_cast<float>(clamped));
 }
 
 void TeslaChargingLimitNumber::control(float value) {

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -150,9 +150,6 @@ public:
     void vent_windows();
     void close_windows();
     
-    // Internal helper methods for state manager
-    void update_charging_amps_max_value(int32_t new_max);
-
     // Manager accessors
     VehicleStateManager* get_state_manager() const { return state_manager_.get(); }
     
@@ -230,6 +227,9 @@ private:
     
     std::string last_rx_hex_;
 
+    // Configured max (stored before state_manager is initialized)
+    int configured_charging_amps_max_{32};
+
     // Friends
     friend class VehicleStateManager;
 };
@@ -301,7 +301,6 @@ DEFINE_TESLA_SWITCH(TeslaSentryModeSwitch, set_sentry_mode)
 class TeslaChargingAmpsNumber : public number::Number {
 public:
     void set_parent(TeslaBLEVehicle *parent) { parent_ = parent; }
-    void update_max_value(int32_t new_max);
 protected:
     void control(float value) override;
     TeslaBLEVehicle *parent_{nullptr};

--- a/components/tesla_ble_vehicle/vehicle_state_manager.cpp
+++ b/components/tesla_ble_vehicle/vehicle_state_manager.cpp
@@ -604,8 +604,7 @@ void VehicleStateManager::update_charging_amps_max(int32_t new_max) {
 
     charging_amps_max_ = new_max;
 
-    if (charging_amps_number_ && parent_) {
-        parent_->update_charging_amps_max_value(new_max);
+    if (charging_amps_number_) {
         ESP_LOGD(STATE_MANAGER_TAG, "Updated max charging amps to %d A", new_max);
     }
 }


### PR DESCRIPTION
The Number entity's max_value trait cannot be dynamically updated in HASS (ESPHome API only sends traits once in ListEntitiesNumberResponse). Instead of modifying traits.set_max_value(), keep the Number at the YAML config value and clamp in set_charging_amps() which already uses the vehicle-reported dynamic max (charge_current_request_max).

Changes:
- Remove update_charging_amps_max_value / update_max_value (traits-based approach)
- set_charging_amps() returns the clamped amps value
- control() publishes the clamped value so slider reflects actual setpoint
- Reset charging_amps_max_ to configured value on each BLE reconnection
- Store configured_charging_amps_max_ directly (set before state_manager init)