### PR TITLE
chore: bump tesla-ble 5.0.4 -> 5.0.5

### DIFF
--- a/packages/board.yml
+++ b/packages/board.yml
@@ -7,4 +7,4 @@ esp32:
     components:
       - name: tesla-ble
         source: https://github.com/yoziru/tesla-ble.git
-        ref: v5.0.4
+        ref: v5.0.5


### PR DESCRIPTION
What's Changed
- tests: add regression coverage for pairing HMAC tag handling
- fix: reset infotainment timeout after wake
- fix: surface CarServer action errors
