### PR TITLE
chore: bump tesla-ble 5.0.5 -> 5.0.6

### DIFF
--- a/packages/board.yml
+++ b/packages/board.yml
@@ -7,4 +7,4 @@ esp32:
     components:
       - name: tesla-ble
         source: https://github.com/yoziru/tesla-ble.git
-        ref: v5.0.5
+        ref: v5.0.6


### PR DESCRIPTION
- fix: align WAITING_FOR_RESPONSE per-attempt timeout with Go reference
- fix: clear rx_buffer on retry to prevent stale data cascade
