### PR TITLE
chore: bump tesla-ble 5.0.6 → 5.1.1

### DIFF
--- a/packages/board.yml
+++ b/packages/board.yml
@@ -7,4 +7,4 @@ esp32:
     components:
       - name: tesla-ble
         source: https://github.com/yoziru/tesla-ble.git
-        ref: v5.0.6
+        ref: v5.1.1


### PR DESCRIPTION
Bump tesla-ble library from v5.0.6 to v5.1.1. The `fix-clang-tidy` branch has been merged, renaming enums to `UPPER_SNAKE_CASE` — source changes for that come in the follow-up feat PR.