### PR TITLE
fix: entity_category 'diagnostic' not applied to any entities

### DIFF
--- a/components/tesla_ble_vehicle/__init__.py
+++ b/components/tesla_ble_vehicle/__init__.py
@@ -13,6 +13,7 @@ from esphome.const import (
     CONF_NAME,
     CONF_RESTORE_MODE,
     CONF_UNIT_OF_MEASUREMENT,
+    ENTITY_CATEGORY_DIAGNOSTIC,
 )
 from esphome import automation
 
@@ -303,6 +304,9 @@ async def create_sensor(var, definition):
         dc = get_device_class_const(sensor, definition["device_class"])
         if dc:
             config[CONF_DEVICE_CLASS] = dc
+    if "entity_category" in definition:
+        if definition["entity_category"] == "diagnostic":
+            config[CONF_ENTITY_CATEGORY] = ENTITY_CATEGORY_DIAGNOSTIC
     
     sens = await sensor.new_sensor(config)
     # Use generic setter with sensor ID
@@ -322,7 +326,7 @@ async def create_text_sensor(var, definition):
         config[CONF_ICON] = definition["icon"]
     if "entity_category" in definition:
         if definition["entity_category"] == "diagnostic":
-            config[CONF_ENTITY_CATEGORY] = cg.EntityCategory.ENTITY_CATEGORY_DIAGNOSTIC
+            config[CONF_ENTITY_CATEGORY] = ENTITY_CATEGORY_DIAGNOSTIC
     
     sens = await text_sensor.new_text_sensor(config)
     if definition.get("setter"):
@@ -343,7 +347,7 @@ async def create_button(var, definition):
         config[CONF_ICON] = definition["icon"]
     if "entity_category" in definition:
         if definition["entity_category"] == "diagnostic":
-            config[CONF_ENTITY_CATEGORY] = cg.EntityCategory.ENTITY_CATEGORY_DIAGNOSTIC
+            config[CONF_ENTITY_CATEGORY] = ENTITY_CATEGORY_DIAGNOSTIC
     
     btn = await button.new_button(config)
     cg.add(btn.set_parent(var))


### PR DESCRIPTION
cg.EntityCategory.ENTITY_CATEGORY_DIAGNOSTIC is a C++ codegen MockObj, not the string 'diagnostic'. ESPHome entity setup does str() on the config value and looks it up in cv.ENTITY_CATEGORIES — the MockObj string never matched, so every entity with entity_category: diagnostic defaulted to NONE.

Fixed by importing ENTITY_CATEGORY_DIAGNOSTIC from esphome.const (the string 'diagnostic').