### PR TITLE
feat: add charger_phases sensor from ChargeState proto

### DIFF
--- a/components/tesla_ble_vehicle/__init__.py
+++ b/components/tesla_ble_vehicle/__init__.py
@@ -142,6 +142,7 @@ SENSORS = [
     {"id": "evse_max_current", "name": "Charger Max", "icon": "mdi:ev-plug-tesla", "device_class": "current", "unit": "A"},
     {"id": "charge_current_request", "name": "Requested Current", "icon": "mdi:current-ac", "device_class": "current", "unit": "A", "entity_category": "diagnostic", "disabled_by_default": True},
     {"id": "vehicle_max_charge_current", "name": "Car Max Acceptable", "icon": "mdi:car-battery", "device_class": "current", "unit": "A"},
+    {"id": "charger_phases", "name": "Charger Phases", "icon": "mdi:sine-wave", "unit": "", "accuracy_decimals": 0},
     {"id": "charging_rate", "name": "Charging Rate", "icon": "mdi:speedometer", "device_class": "speed", "unit": "mph", "accuracy_decimals": 1},
     {"id": "energy_added", "name": "Energy Added", "icon": "mdi:battery-charging", "device_class": "energy", "unit": "kWh", "accuracy_decimals": 1},
     {"id": "time_to_full", "name": "Time to Full", "icon": "mdi:clock-outline", "device_class": "duration", "unit": "min"},

--- a/components/tesla_ble_vehicle/vehicle_state_manager.cpp
+++ b/components/tesla_ble_vehicle/vehicle_state_manager.cpp
@@ -310,6 +310,14 @@ void VehicleStateManager::update_charge_state(const CarServer_ChargeState& charg
         }
     }
     
+    // Update charger phases (1-phase vs 3-phase)
+    if (charge_state.which_optional_charger_phases) {
+        const float phases = static_cast<float>(charge_state.optional_charger_phases.charger_phases);
+        if (phases >= 1.0f && phases <= 3.0f && std::isfinite(phases)) {
+            publish_sensor("charger_phases", phases);
+        }
+    }
+
     // Update charge port latch lock (cable latch engaged/disengaged)
     if (charge_state.has_charge_port_latch) {
         // Engaged = locked (cable secured), Disengaged = unlocked (cable can be removed)


### PR DESCRIPTION
Adds a new numeric sensor for `charger_phases` (1-phase vs 3-phase) from the `ChargeState` proto (field 134). Enabled by default, no unit, accuracy 0 (integer values only).

Changes:
- `vehicle_state_manager.cpp` — read `optional_charger_phases` and publish
- `__init__.py` — register the sensor definition

Closes #162