### PR TITLE
fix: let idle and unlocked cars sleep (only charging/sentry keep them awake)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ The Tesla backend enforces these restrictions. Change requires re-pairing.
 tesla_ble_vehicle:
   vcsec_poll_interval: 10               # Status updates (always safe, low power)
   infotainment_poll_interval_awake: 30  # Detailed data when idle
-  infotainment_poll_interval_active: 10 # Detailed data when charging/unlocked
-  infotainment_sleep_timeout: 660       # Idle minutes before sleep (default 11)
+  infotainment_poll_interval_active: 10 # Detailed data when charging/sentry mode
+  infotainment_sleep_timeout: 660       # Idle seconds before letting the car sleep (default 11 min)
 ```
 
-The system only polls infotainment data during an 11-minute wake window, then lets the car sleep. Active states (charging, unlocked, user present) keep it awake for continuous updates. VCSEC status polling is low-power and does not affect vehicle sleep.
+The system only polls infotainment data during an 11-minute wake window, then lets the car sleep. Active charging and sentry mode keep it awake for continuous updates. A car that is merely left unlocked, or that reports user presence because a phone is in range, is treated as idle — the integration backs off and lets it sleep regardless. VCSEC status polling is low-power and does not affect vehicle sleep.
 
 ## Usage
 
@@ -184,7 +184,7 @@ Install a BLE scanner app (nRF Connect, LightBlue), scan nearby devices, and loo
 |---------|-------------|
 | "Found Tesla vehicle" never appears | The listener isn't enabled. For CLI: uncomment `listener: !include listener.yml` in `packages/base.yml`. For Dashboard: add `tesla_ble_listener:` block to your YAML (see above). VCSEC always advertises — no need to wake the car. |
 | Pairing fails with HMAC error | BLE MAC or VIN is wrong. Verify both in `secrets.yaml`. |
-| Car stays awake | Sentry Mode, recent drive, or state flapping keeps resetting the 11-min sleep timeout. |
+| Car stays awake | Active charging or sentry mode keep it awake. Otherwise the integration backs off after `infotainment_sleep_timeout` of idle time and lets the car sleep — watch the log for `Polling Infotainment (sleeping - NO_WAKE_SKIP)`. |
 | `Unknown` on boot | Normal for some sensors — VCSEC corrects within ~10s. |
 | Compile errors | Board mismatch? Run `make clean`, then `make compile` again. |
 | `uv: command not found` | Install [uv](https://docs.astral.sh/uv/getting-started/installation/) |

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -197,14 +197,22 @@ void TeslaBLEVehicle::update() {
 
   // Infotainment Polling - use faster interval when vehicle is active
   const bool is_asleep = state_manager_->is_asleep();
+  // Only sentry mode and active charging warrant keeping the car awake. A car
+  // that is merely left unlocked, or reports user presence because a phone is
+  // in range, can still fall asleep on its own and must be allowed to do so
+  // (issues #201/#202). To add faster polling for unlocked/user-present later,
+  // extend this expression (and gate it behind an opt-in config).
   const bool is_active = state_manager_->is_charging() ||
-                         state_manager_->is_user_present() ||
-                         state_manager_->is_unlocked();
+                         state_manager_->is_sentry_mode();
 
   // Infotainment polling with WAKE_IF_NEEDED keeps the car awake, preventing
   // VCSEC from ever reporting ASLEEP. After infotainment_sleep_timeout_ of idle
   // time, use NO_WAKE_SKIP to let the car naturally fall asleep.
-  if (is_asleep || is_active) {
+  //
+  // Only genuine activity resets the idle timer. A car that is merely observed
+  // asleep, or briefly blips awake on its own, must not restart the aggressive
+  // polling window or it would be re-woken every time it tried to sleep.
+  if (is_active) {
     last_awake_idle_start_ = now;
   } else if (last_awake_idle_start_ == 0) {
     last_awake_idle_start_ = now;
@@ -220,9 +228,11 @@ void TeslaBLEVehicle::update() {
   }
 
   if (now - last_infotainment_poll_ >= infotainment_interval) {
-    ESP_LOGI(TAG, "Polling Infotainment");
     auto policy = effective_asleep ? TeslaBLE::WakePolicy::NO_WAKE_SKIP
                                    : TeslaBLE::WakePolicy::WAKE_IF_NEEDED;
+    ESP_LOGI(TAG, "Polling Infotainment (%s)",
+             effective_asleep ? "sleeping - NO_WAKE_SKIP"
+                              : "active - WAKE_IF_NEEDED");
     vehicle_->infotainment_poll(policy);
     last_infotainment_poll_ = now;
   }

--- a/components/tesla_ble_vehicle/vehicle_state_manager.cpp
+++ b/components/tesla_ble_vehicle/vehicle_state_manager.cpp
@@ -540,7 +540,6 @@ void VehicleStateManager::update_user_present(bool present) {
     if (publish_binary_sensor("user_present", present)) {
         ESP_LOGI(STATE_MANAGER_TAG, "User presence: %s", present ? "PRESENT" : "NOT_PRESENT");
     }
-    is_user_present_ = present;
 }
 
 void VehicleStateManager::update_charge_flap_open(bool open) {
@@ -588,17 +587,8 @@ bool VehicleStateManager::is_asleep() const {
     return sensor ? sensor->state : true;
 }
 
-bool VehicleStateManager::is_unlocked() const {
-    // Use doors lock entity state if available, otherwise check binary sensor
-    if (doors_lock_) {
-        return doors_lock_->state == lock::LOCK_STATE_UNLOCKED;
-    }
-    return false;
-}
-
-bool VehicleStateManager::is_user_present() const {
-    auto* sensor = get_binary_sensor("user_present");
-    return sensor ? sensor->state : false;
+bool VehicleStateManager::is_sentry_mode() const {
+    return sentry_mode_switch_ != nullptr && sentry_mode_switch_->state;
 }
 
 bool VehicleStateManager::is_charge_flap_open() const {

--- a/components/tesla_ble_vehicle/vehicle_state_manager.h
+++ b/components/tesla_ble_vehicle/vehicle_state_manager.h
@@ -119,8 +119,7 @@ public:
     // State queries
     // ==========================================================================
     bool is_asleep() const;
-    bool is_unlocked() const;
-    bool is_user_present() const;
+    bool is_sentry_mode() const;
     bool is_charge_flap_open() const;
     bool is_charging() const { return is_charging_; }
     float get_charging_amps() const;
@@ -167,7 +166,6 @@ private:
     // Internal state tracking
     // ==========================================================================
     bool is_charging_{false};
-    bool is_user_present_{false};
     int charging_amps_max_{32};
     
     // Climate state tracking

--- a/packages/client.yml
+++ b/packages/client.yml
@@ -24,8 +24,8 @@ tesla_ble_vehicle:
   # Polling intervals (in seconds) - adjust based on your battery life vs responsiveness needs
   vcsec_poll_interval: $vcsec_poll_interval        # Vehicle status polling (also sets ESPHome update_interval)
   infotainment_poll_interval_awake: $infotainment_poll_interval_awake    # Data polling when awake but not active
-  infotainment_poll_interval_active: $infotainment_poll_interval_active # Data polling when charging/unlocked/user present (more responsive)
-  infotainment_sleep_timeout: $infotainment_sleep_timeout  # How long to poll before allowing sleep
+  infotainment_poll_interval_active: $infotainment_poll_interval_active # Data polling when charging/sentry mode (more responsive)
+  infotainment_sleep_timeout: $infotainment_sleep_timeout  # Idle time before polls stop waking the car (letting it sleep)
 
 # BLE sensors from the standard ble_client platform
 sensor:


### PR DESCRIPTION
Fixes #201 (wakes car) and #202 (left unlocked, never sleeps).

Builds on #198: the idle timeout was gated behind an `is_active` that included `is_unlocked()`/`is_user_present()`, and the timer was reset while the car was observed asleep. So an unlocked/idle (or phone-in-range) car was polled with `WAKE_IF_NEEDED` every ~10s — which wakes a sleeping vehicle — and every natural awake blip re-armed the 11-min aggressive window.

Changes:
- `is_active` is now `charging || sentry_mode` only; unlocked/user-present cars are treated as idle and back off to `NO_WAKE_SKIP` after `infotainment_sleep_timeout`
- idle timer resets only on genuine activity, so natural wake blips no longer restart the aggressive window
- removed now-unused `is_unlocked()`/`is_user_present()` queries; added `is_sentry_mode()`
- poll log now shows the policy (e.g. `Polling Infotainment (sleeping - NO_WAKE_SKIP)`)

No new configuration.