### PR TITLE
test: unit test framework for C++ logic + Python codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  tests:
+    name: Unit tests (C++ + Python)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+      - name: Run tests
+        run: make test
+
   ci:
     name: Building ${{ matrix.file }}
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ firmware.bin.gz
 foo
 *.log
 .selected_suffix
+tests/build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ make compile_docker [BOARD=<board>]       # Compile using Docker
 make validate-config [BOARD=<board>]      # Validate YAML without building
 make upload [BOARD=<board>] [HOST_SUFFIX] # Flash firmware to device
 make logs [HOST_SUFFIX]                   # View device logs
+make test                                 # Run unit tests (C++ + Python)
 make clean                                # Remove .esphome build dir
 make help                                 # Show all targets
 
@@ -38,6 +39,16 @@ Error handling: Check pointers before use. Return bool for success/failure helpe
 # Key Conventions
 - VCSEC is always safe to poll (low-power controller, doesn't wake vehicle)
 - Sleep state is detected via VCSEC; infotainment uses NO_WAKE_SKIP when asleep
+- Polling decision logic (idle/awake/charging/sentry cadence + wake policy) lives in
+  components/tesla_ble_vehicle/polling_policy.h (dependency-free, unit-testable); tesla_ble_vehicle.cpp wires it to ESPHome
+- Raw state -> text/flag conversions (sleep/lock/presence/charging/shift/charge-limit) live in
+  components/tesla_ble_vehicle/state_text.h (dependency-free, values static_asserted against the tesla-ble protobuf headers in vehicle_state_manager.cpp)
 - Sensors defined in __init__.py SENSORS/BINARY_SENSORS/TEXT_SENSORS lists
 - Sensor values published in vehicle_state_manager.cpp update methods
 - Commands use TeslaBLEVehicle::send_command() with Command tracking
+
+# Testing
+- make test runs C++ + Python unit tests (fast, no ESPHome/device needed). CI runs it on every PR.
+- C++: tests/test_polling_policy.cpp and tests/test_state_text.cpp (plain compiler, no framework).
+  Add behavior-level test cases there.
+- Python: tests/test_codegen.py (stdlib-only ast checks on entity lists in __init__.py).

--- a/Makefile.common
+++ b/Makefile.common
@@ -73,8 +73,38 @@ discover: ## Discover ESPHome devices on the network
 	fi'
 
 .PHONY: clean
-clean: ## Remove the esphome build directory
-	rm -rf .esphome .selected_suffix
+clean: ## Remove the esphome build directory and test artifacts
+	rm -rf .esphome .selected_suffix $(TEST_BUILD_DIR)
+
+# ---------------------------------------------------------------------------
+# Tests (unit tests for the C++ logic + Python codegen checks)
+# ---------------------------------------------------------------------------
+CXX ?= c++
+TEST_DIR ?= tests
+TEST_BUILD_DIR ?= $(TEST_DIR)/build
+TEST_INCLUDE_DIRS ?= -Icomponents/tesla_ble_vehicle
+TEST_CXXFLAGS ?= -std=c++17 -Wall -Wextra
+
+# Each tests/test_*.cpp compiles to its own binary.
+TEST_BINS := \
+  $(TEST_BUILD_DIR)/test_polling_policy \
+  $(TEST_BUILD_DIR)/test_state_text
+
+.PHONY: test test-cpp test-python
+test: test-cpp test-python ## Run the unit tests (C++ and Python)
+
+test-cpp: $(TEST_BINS) ## Build and run the C++ unit tests
+	@for bin in $(TEST_BINS); do \
+	  echo "== $$bin =="; \
+	  $$bin || exit 1; \
+	done
+
+$(TEST_BUILD_DIR)/test_%: $(TEST_DIR)/test_%.cpp components/tesla_ble_vehicle/polling_policy.h components/tesla_ble_vehicle/state_text.h
+	mkdir -p $(TEST_BUILD_DIR)
+	$(CXX) $(TEST_CXXFLAGS) $(TEST_INCLUDE_DIRS) $< -o $@
+
+test-python: ## Run the Python codegen checks
+	python3 $(TEST_DIR)/test_codegen.py
 
 .PHONY: help
 help: ## Show help messages for make targets

--- a/components/tesla_ble_vehicle/polling_policy.h
+++ b/components/tesla_ble_vehicle/polling_policy.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstdint>
+
+namespace esphome {
+namespace tesla_ble_vehicle {
+
+// Whether infotainment polling is allowed to wake the vehicle. A vehicle that
+// is observed asleep, or has been idle past the sleep timeout, must be polled
+// with NO_WAKE_SKIP so it can stay asleep.
+enum class WakePolicy : uint8_t { WAKE_IF_NEEDED, NO_WAKE_SKIP };
+
+struct InfotainmentPollDecision {
+  uint32_t interval_ms;
+  WakePolicy wake_policy;
+};
+
+// Decides the infotainment polling cadence and wake policy from the current
+// vehicle state. Pure logic with no ESPHome or tesla-ble dependency so it can
+// be unit-tested in isolation (see tests/test_polling_policy.cpp).
+//
+// Behaviour:
+//  - Active charging or sentry mode keep the car awake: fast interval with
+//    WAKE_IF_NEEDED, and the idle window keeps being refreshed.
+//  - Otherwise the car is treated as idle: it is polled gently at the awake
+//    interval, and after sleep_timeout_ms of idle time it backs off to
+//    NO_WAKE_SKIP so the car can fall asleep on its own.
+//  - Only genuine activity resets the idle timer. A car that is observed
+//    asleep, or briefly blips awake on its own, must not restart the aggressive
+//    window or it would be re-woken every time it tried to sleep (#201/#202).
+class InfotainmentPollPolicy {
+public:
+  void set_awake_interval_ms(uint32_t interval_ms) { awake_interval_ms_ = interval_ms; }
+  void set_active_interval_ms(uint32_t interval_ms) { active_interval_ms_ = interval_ms; }
+  void set_sleep_timeout_ms(uint32_t interval_ms) { sleep_timeout_ms_ = interval_ms; }
+
+  uint32_t awake_interval_ms() const { return awake_interval_ms_; }
+  uint32_t active_interval_ms() const { return active_interval_ms_; }
+  uint32_t sleep_timeout_ms() const { return sleep_timeout_ms_; }
+
+  // Forget the idle timing, e.g. on (re)connect. The next update() starts a
+  // fresh idle window.
+  void reset() { idle_since_ms_ = 0; }
+
+  InfotainmentPollDecision update(uint32_t now_ms, bool is_asleep, bool is_charging, bool is_sentry_mode) {
+    const bool active = is_charging || is_sentry_mode;
+    if (active) {
+      idle_since_ms_ = now_ms;
+    } else if (idle_since_ms_ == 0) {
+      idle_since_ms_ = now_ms;
+    }
+    const bool effective_asleep =
+        is_asleep || (!active && (now_ms - idle_since_ms_ >= sleep_timeout_ms_));
+
+    uint32_t interval_ms = awake_interval_ms_;
+    if (effective_asleep) {
+      interval_ms = sleep_timeout_ms_;
+    } else if (active) {
+      interval_ms = active_interval_ms_;
+    }
+    return {interval_ms,
+            effective_asleep ? WakePolicy::NO_WAKE_SKIP : WakePolicy::WAKE_IF_NEEDED};
+  }
+
+private:
+  uint32_t awake_interval_ms_{30000};
+  uint32_t active_interval_ms_{10000};
+  uint32_t sleep_timeout_ms_{660000};
+  uint32_t idle_since_ms_{0};
+};
+
+}  // namespace tesla_ble_vehicle
+}  // namespace esphome

--- a/components/tesla_ble_vehicle/state_text.h
+++ b/components/tesla_ble_vehicle/state_text.h
@@ -1,0 +1,187 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace esphome {
+namespace tesla_ble_vehicle {
+namespace state_text {
+
+// Raw protobuf enum/tag values, duplicated from the nanopb-generated headers of
+// the external tesla-ble library (vcsec.pb.h, vehicle.pb.h). Kept here so this
+// module has no external dependency and can be unit-tested in isolation.
+// vehicle_state_manager.cpp static_asserts these match the library values.
+
+// VCSEC_VehicleSleepStatus_E
+constexpr int kSleepUnknown = 0;
+constexpr int kSleepAwake = 1;
+constexpr int kSleepAsleep = 2;
+
+// VCSEC_VehicleLockState_E
+constexpr int kLockUnlocked = 0;
+constexpr int kLockLocked = 1;
+constexpr int kLockInternalLocked = 2;
+constexpr int kLockSelectiveUnlocked = 3;
+
+// VCSEC_UserPresence_E
+constexpr int kPresenceUnknown = 0;
+constexpr int kPresenceNotPresent = 1;
+constexpr int kPresencePresent = 2;
+
+// CarServer_ChargeState_ChargingState tags (which_type)
+constexpr int kChargingStateUnknown = 1;
+constexpr int kChargingStateDisconnected = 2;
+constexpr int kChargingStateNoPower = 3;
+constexpr int kChargingStateStarting = 4;
+constexpr int kChargingStateCharging = 5;
+constexpr int kChargingStateComplete = 6;
+constexpr int kChargingStateStopped = 7;
+constexpr int kChargingStateCalibrating = 8;
+
+// CarServer_ShiftState tags (which_type)
+constexpr int kShiftInvalid = 1;
+constexpr int kShiftP = 2;
+constexpr int kShiftR = 3;
+constexpr int kShiftN = 4;
+constexpr int kShiftD = 5;
+constexpr int kShiftSNA = 6;
+
+// CarServer_ChargeState_ChargeLimitReason
+constexpr int kLimitUnknown = 0;
+constexpr int kLimitNone = 1;
+constexpr int kLimitEvse = 2;
+constexpr int kLimitBattTempLow = 3;
+constexpr int kLimitHighSoc = 4;
+constexpr int kLimitCabin = 5;
+
+// Map a VCSEC enum to true/false, or nullopt when the status is unknown.
+inline std::optional<bool> sleep_status(int status) {
+  switch (status) {
+    case kSleepAwake:
+      return false;
+    case kSleepAsleep:
+      return true;
+    default:
+      return std::nullopt;
+  }
+}
+
+inline std::optional<bool> lock_status(int status) {
+  switch (status) {
+    case kLockUnlocked:
+    case kLockSelectiveUnlocked:
+      return true;
+    case kLockLocked:
+    case kLockInternalLocked:
+      return false;
+    default:
+      return std::nullopt;
+  }
+}
+
+inline std::optional<bool> user_presence(int presence) {
+  switch (presence) {
+    case kPresencePresent:
+      return true;
+    case kPresenceNotPresent:
+      return false;
+    default:
+      return std::nullopt;
+  }
+}
+
+// Whether a charging-state tag means the car is actively charging.
+inline bool is_charging(int which_type) {
+  return which_type == kChargingStateCharging || which_type == kChargingStateStarting;
+}
+
+inline std::string charging_state(int which_type) {
+  switch (which_type) {
+    case kChargingStateDisconnected:
+      return "Disconnected";
+    case kChargingStateNoPower:
+      return "No Power";
+    case kChargingStateStarting:
+      return "Starting";
+    case kChargingStateCharging:
+      return "Charging";
+    case kChargingStateComplete:
+      return "Complete";
+    case kChargingStateStopped:
+      return "Stopped";
+    case kChargingStateCalibrating:
+      return "Calibrating";
+    default:
+      return "Unknown";
+  }
+}
+
+inline bool charger_connected(int which_type) {
+  switch (which_type) {
+    case kChargingStateDisconnected:
+    case kChargingStateUnknown:
+      return false;
+    default:
+      return true;
+  }
+}
+
+inline std::string iec61851_state(int which_type) {
+  switch (which_type) {
+    case kChargingStateDisconnected:
+      return "A";
+    case kChargingStateNoPower:
+      return "E";
+    case kChargingStateStarting:
+    case kChargingStateCharging:
+    case kChargingStateCalibrating:
+      return "C";
+    case kChargingStateComplete:
+    case kChargingStateStopped:
+      return "B";
+    default:
+      return "F";
+  }
+}
+
+inline std::string shift_state(int which_type) {
+  switch (which_type) {
+    case kShiftP:
+      return "P";
+    case kShiftR:
+      return "R";
+    case kShiftN:
+      return "N";
+    case kShiftD:
+      return "D";
+    case kShiftSNA:
+      return "SNA";
+    case kShiftInvalid:
+      return "Invalid";
+    default:
+      return "Unknown";
+  }
+}
+
+inline bool is_parked(int which_type) { return which_type == kShiftP; }
+
+inline std::string charge_limit_reason(int reason) {
+  switch (reason) {
+    case kLimitNone:
+      return "None";
+    case kLimitEvse:
+      return "EVSE";
+    case kLimitBattTempLow:
+      return "BattTempLow";
+    case kLimitHighSoc:
+      return "HighSoc";
+    case kLimitCabin:
+      return "Cabin";
+    default:
+      return "Unknown";
+  }
+}
+
+}  // namespace state_text
+}  // namespace tesla_ble_vehicle
+}  // namespace esphome

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -201,38 +201,20 @@ void TeslaBLEVehicle::update() {
   // that is merely left unlocked, or reports user presence because a phone is
   // in range, can still fall asleep on its own and must be allowed to do so
   // (issues #201/#202). To add faster polling for unlocked/user-present later,
-  // extend this expression (and gate it behind an opt-in config).
-  const bool is_active = state_manager_->is_charging() ||
-                         state_manager_->is_sentry_mode();
+  // extend the decision inputs here (and gate it behind an opt-in config).
+  InfotainmentPollDecision decision =
+      poll_policy_.update(now, is_asleep, state_manager_->is_charging(),
+                          state_manager_->is_sentry_mode());
 
-  // Infotainment polling with WAKE_IF_NEEDED keeps the car awake, preventing
-  // VCSEC from ever reporting ASLEEP. After infotainment_sleep_timeout_ of idle
-  // time, use NO_WAKE_SKIP to let the car naturally fall asleep.
-  //
-  // Only genuine activity resets the idle timer. A car that is merely observed
-  // asleep, or briefly blips awake on its own, must not restart the aggressive
-  // polling window or it would be re-woken every time it tried to sleep.
-  if (is_active) {
-    last_awake_idle_start_ = now;
-  } else if (last_awake_idle_start_ == 0) {
-    last_awake_idle_start_ = now;
-  }
-  const bool effective_asleep = is_asleep ||
-    (!is_active && (now - last_awake_idle_start_ >= infotainment_sleep_timeout_));
-
-  uint32_t infotainment_interval = infotainment_poll_interval_awake_;
-  if (effective_asleep) {
-    infotainment_interval = infotainment_sleep_timeout_;
-  } else if (is_active) {
-    infotainment_interval = infotainment_poll_interval_active_;
-  }
-
-  if (now - last_infotainment_poll_ >= infotainment_interval) {
-    auto policy = effective_asleep ? TeslaBLE::WakePolicy::NO_WAKE_SKIP
-                                   : TeslaBLE::WakePolicy::WAKE_IF_NEEDED;
+  if (now - last_infotainment_poll_ >= decision.interval_ms) {
+    TeslaBLE::WakePolicy policy =
+        decision.wake_policy == WakePolicy::NO_WAKE_SKIP
+            ? TeslaBLE::WakePolicy::NO_WAKE_SKIP
+            : TeslaBLE::WakePolicy::WAKE_IF_NEEDED;
     ESP_LOGI(TAG, "Polling Infotainment (%s)",
-             effective_asleep ? "sleeping - NO_WAKE_SKIP"
-                              : "active - WAKE_IF_NEEDED");
+             decision.wake_policy == WakePolicy::NO_WAKE_SKIP
+                 ? "sleeping - NO_WAKE_SKIP"
+                 : "active - WAKE_IF_NEEDED");
     vehicle_->infotainment_poll(policy);
     last_infotainment_poll_ = now;
   }
@@ -245,8 +227,8 @@ void TeslaBLEVehicle::dump_config() {
   ESP_LOGCONFIG(TAG, "  Max Charging Amps: %d",
                 state_manager_ ? state_manager_->get_charging_amps_max() : 32);
   ESP_LOGCONFIG(TAG, "  Polling: VCSEC=%ums, Awake=%ums, Active=%ums",
-                vcsec_poll_interval_, infotainment_poll_interval_awake_,
-                infotainment_poll_interval_active_);
+                vcsec_poll_interval_, poll_policy_.awake_interval_ms(),
+                poll_policy_.active_interval_ms());
   ESP_LOGCONFIG(TAG, "  Sensors: %d binary, %d numeric, %d text",
                 pending_binary_sensors_.size(), pending_sensors_.size(),
                 pending_text_sensors_.size());
@@ -298,19 +280,19 @@ void TeslaBLEVehicle::set_vcsec_poll_interval(uint32_t interval_ms) {
 void TeslaBLEVehicle::set_infotainment_poll_interval_awake(
     uint32_t interval_ms) {
   ESP_LOGD(TAG, "Setting infotainment poll interval awake: %u ms", interval_ms);
-  infotainment_poll_interval_awake_ = interval_ms;
+  poll_policy_.set_awake_interval_ms(interval_ms);
 }
 
 void TeslaBLEVehicle::set_infotainment_poll_interval_active(
     uint32_t interval_ms) {
   ESP_LOGD(TAG, "Setting infotainment poll interval active: %u ms",
            interval_ms);
-  infotainment_poll_interval_active_ = interval_ms;
+  poll_policy_.set_active_interval_ms(interval_ms);
 }
 
 void TeslaBLEVehicle::set_infotainment_sleep_timeout(uint32_t interval_ms) {
   ESP_LOGD(TAG, "Setting infotainment sleep timeout: %u ms", interval_ms);
-  infotainment_sleep_timeout_ = interval_ms;
+  poll_policy_.set_sleep_timeout_ms(interval_ms);
 }
 
 // =============================================================================
@@ -559,7 +541,7 @@ int TeslaBLEVehicle::regenerate_key() {
 
 void TeslaBLEVehicle::force_update() {
   uint32_t now = millis();
-  if (now - last_infotainment_poll_ < infotainment_poll_interval_active_) {
+  if (now - last_infotainment_poll_ < poll_policy_.active_interval_ms()) {
     ESP_LOGD(TAG, "Force update requested too soon (within active polling "
                   "interval) - ignoring");
     return;
@@ -956,7 +938,7 @@ void TeslaBLEVehicle::handle_connection_established() {
     vehicle_->infotainment_poll(TeslaBLE::WakePolicy::WAKE_IF_NEEDED);
     last_vcsec_poll_ = millis();
     last_infotainment_poll_ = millis();
-    last_awake_idle_start_ = 0;
+    poll_policy_.reset();
   }
 
   // Reset charging amps max to configured value on each connection
@@ -975,7 +957,7 @@ void TeslaBLEVehicle::handle_connection_lost() {
 
   last_infotainment_poll_ = 0;
   last_vcsec_poll_ = 0;
-  last_awake_idle_start_ = 0;
+  poll_policy_.reset();
   this->status_set_warning("BLE connection lost");
 }
 

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -19,6 +19,7 @@
 #include <esphome/core/automation.h>
 
 #include "ble_adapter_impl.h"
+#include "polling_policy.h"
 #include "storage_adapter_impl.h"
 #include <vehicle.h>
 #include "vehicle_state_manager.h"
@@ -185,14 +186,11 @@ private:
     
     // Polling intervals
     uint32_t vcsec_poll_interval_{10000};
-    uint32_t infotainment_poll_interval_awake_{30000};
-    uint32_t infotainment_poll_interval_active_{10000};
-    uint32_t infotainment_sleep_timeout_{660000};
     
     // Polling state
     uint32_t last_vcsec_poll_{0};
     uint32_t last_infotainment_poll_{0};
-    uint32_t last_awake_idle_start_{0};
+    InfotainmentPollPolicy poll_policy_;
 
     // BLE state
     espbt::ESPBTUUID service_uuid_;

--- a/components/tesla_ble_vehicle/vehicle_state_manager.cpp
+++ b/components/tesla_ble_vehicle/vehicle_state_manager.cpp
@@ -1,4 +1,5 @@
 #include "vehicle_state_manager.h"
+#include "state_text.h"
 #include "tesla_ble_vehicle.h"
 #include <esphome/core/helpers.h>
 #include <cmath>
@@ -6,6 +7,38 @@
 
 namespace esphome {
 namespace tesla_ble_vehicle {
+
+// The raw values duplicated in state_text.h must match the nanopb-generated
+// enums/tags from the tesla-ble library, or every state conversion would be
+// wrong. Compile-time check.
+static_assert(static_cast<int>(VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_AWAKE) == state_text::kSleepAwake);
+static_assert(static_cast<int>(VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_ASLEEP) == state_text::kSleepAsleep);
+static_assert(static_cast<int>(VCSEC_VehicleLockState_E_VEHICLELOCKSTATE_UNLOCKED) == state_text::kLockUnlocked);
+static_assert(static_cast<int>(VCSEC_VehicleLockState_E_VEHICLELOCKSTATE_LOCKED) == state_text::kLockLocked);
+static_assert(static_cast<int>(VCSEC_VehicleLockState_E_VEHICLELOCKSTATE_INTERNAL_LOCKED) == state_text::kLockInternalLocked);
+static_assert(static_cast<int>(VCSEC_VehicleLockState_E_VEHICLELOCKSTATE_SELECTIVE_UNLOCKED) == state_text::kLockSelectiveUnlocked);
+static_assert(static_cast<int>(VCSEC_UserPresence_E_VEHICLE_USER_PRESENCE_NOT_PRESENT) == state_text::kPresenceNotPresent);
+static_assert(static_cast<int>(VCSEC_UserPresence_E_VEHICLE_USER_PRESENCE_PRESENT) == state_text::kPresencePresent);
+static_assert(CarServer_ChargeState_ChargingState_Unknown_tag == state_text::kChargingStateUnknown);
+static_assert(CarServer_ChargeState_ChargingState_Disconnected_tag == state_text::kChargingStateDisconnected);
+static_assert(CarServer_ChargeState_ChargingState_NoPower_tag == state_text::kChargingStateNoPower);
+static_assert(CarServer_ChargeState_ChargingState_Starting_tag == state_text::kChargingStateStarting);
+static_assert(CarServer_ChargeState_ChargingState_Charging_tag == state_text::kChargingStateCharging);
+static_assert(CarServer_ChargeState_ChargingState_Complete_tag == state_text::kChargingStateComplete);
+static_assert(CarServer_ChargeState_ChargingState_Stopped_tag == state_text::kChargingStateStopped);
+static_assert(CarServer_ChargeState_ChargingState_Calibrating_tag == state_text::kChargingStateCalibrating);
+static_assert(CarServer_ShiftState_Invalid_tag == state_text::kShiftInvalid);
+static_assert(CarServer_ShiftState_P_tag == state_text::kShiftP);
+static_assert(CarServer_ShiftState_R_tag == state_text::kShiftR);
+static_assert(CarServer_ShiftState_N_tag == state_text::kShiftN);
+static_assert(CarServer_ShiftState_D_tag == state_text::kShiftD);
+static_assert(CarServer_ShiftState_SNA_tag == state_text::kShiftSNA);
+static_assert(static_cast<int>(CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonUnknown) == state_text::kLimitUnknown);
+static_assert(static_cast<int>(CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonNone) == state_text::kLimitNone);
+static_assert(static_cast<int>(CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonEvse) == state_text::kLimitEvse);
+static_assert(static_cast<int>(CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonBattTempLow) == state_text::kLimitBattTempLow);
+static_assert(static_cast<int>(CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonHighSoc) == state_text::kLimitHighSoc);
+static_assert(static_cast<int>(CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonCabin) == state_text::kLimitCabin);
 
 VehicleStateManager::VehicleStateManager(TeslaBLEVehicle* parent)
     : parent_(parent) {}
@@ -107,7 +140,7 @@ void VehicleStateManager::update_vehicle_status(const VCSEC_VehicleStatus& statu
 }
 
 void VehicleStateManager::update_sleep_status(VCSEC_VehicleSleepStatus_E status) {
-    auto asleep = convert_sleep_status(status);
+    auto asleep = state_text::sleep_status(static_cast<int>(status));
     if (asleep.has_value()) {
         update_asleep(asleep.value());
     } else {
@@ -116,14 +149,14 @@ void VehicleStateManager::update_sleep_status(VCSEC_VehicleSleepStatus_E status)
 }
 
 void VehicleStateManager::update_lock_status(VCSEC_VehicleLockState_E status) {
-    auto unlocked = convert_lock_status(status);
+    auto unlocked = state_text::lock_status(static_cast<int>(status));
     if (unlocked.has_value()) {
         update_unlocked(unlocked.value());
     }
 }
 
 void VehicleStateManager::update_user_presence(VCSEC_UserPresence_E presence) {
-    auto present = convert_user_presence(presence);
+    auto present = state_text::user_presence(static_cast<int>(presence));
     if (present.has_value()) {
         update_user_present(present.value());
     } else {
@@ -141,10 +174,7 @@ void VehicleStateManager::update_charge_state(const CarServer_ChargeState& charg
     // Update charging status and charging state text
     if (charge_state.has_charging_state) {
         const bool was_charging = is_charging_;
-        const bool new_charging_state = (
-            charge_state.charging_state.which_type == CarServer_ChargeState_ChargingState_Charging_tag ||
-            charge_state.charging_state.which_type == CarServer_ChargeState_ChargingState_Starting_tag
-        );
+        const bool new_charging_state = state_text::is_charging(charge_state.charging_state.which_type);
         
         ESP_LOGD(STATE_MANAGER_TAG, "Charging state check: was=%s, new=%s, state_type=%d", 
                  was_charging ? "ON" : "OFF", 
@@ -164,11 +194,11 @@ void VehicleStateManager::update_charge_state(const CarServer_ChargeState& charg
         }
         
         // Update text sensors
-        publish_text_sensor("charging_state", get_charging_state_text(charge_state.charging_state));
-        publish_text_sensor("iec61851_state", get_iec61851_state_text(charge_state.charging_state));
+        publish_text_sensor("charging_state", state_text::charging_state(charge_state.charging_state.which_type));
+        publish_text_sensor("iec61851_state", state_text::iec61851_state(charge_state.charging_state.which_type));
         
         // Update charger connected binary sensor
-        const bool charger_connected = is_charger_connected_from_state(charge_state.charging_state);
+        const bool charger_connected = state_text::charger_connected(charge_state.charging_state.which_type);
         publish_binary_sensor("charger", charger_connected);
     }
     
@@ -276,7 +306,7 @@ void VehicleStateManager::update_charge_state(const CarServer_ChargeState& charg
     // Some BLE responses omit charge_limit_reason even when charging is externally limited.
     if (charge_state.which_optional_charge_limit_reason) {
         const auto reason = charge_state.optional_charge_limit_reason.charge_limit_reason;
-        publish_text_sensor("charge_limit_reason", get_charge_limit_reason_text(reason));
+        publish_text_sensor("charge_limit_reason", state_text::charge_limit_reason(static_cast<int>(reason)));
     } else if (appears_externally_limited) {
         publish_text_sensor("charge_limit_reason", "ExternalLimit");
     } else {
@@ -385,10 +415,10 @@ void VehicleStateManager::update_drive_state(const CarServer_DriveState& drive_s
     
     // Shift state
     if (drive_state.has_shift_state) {
-        publish_text_sensor("shift_state", get_shift_state_text(drive_state.shift_state));
+        publish_text_sensor("shift_state", state_text::shift_state(drive_state.shift_state.which_type));
         
         // Parking brake sensor - true when in P
-        const bool parked = (drive_state.shift_state.which_type == CarServer_ShiftState_P_tag);
+        const bool parked = state_text::is_parked(drive_state.shift_state.which_type);
         publish_binary_sensor("parking_brake", parked);
     }
     
@@ -677,105 +707,6 @@ void VehicleStateManager::set_sensor_available(binary_sensor::BinarySensor* sens
 void VehicleStateManager::set_sensor_available(sensor::Sensor* sensor, bool available) {
     if (sensor != nullptr) {
         sensor->set_has_state(available);
-    }
-}
-
-// =============================================================================
-// State conversion helpers
-// =============================================================================
-
-std::optional<bool> VehicleStateManager::convert_sleep_status(VCSEC_VehicleSleepStatus_E status) {
-    switch (status) {
-        case VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_AWAKE:
-            return false;
-        case VCSEC_VehicleSleepStatus_E_VEHICLE_SLEEP_STATUS_ASLEEP:
-            return true;
-        default:
-            return std::nullopt;
-    }
-}
-
-std::optional<bool> VehicleStateManager::convert_lock_status(VCSEC_VehicleLockState_E status) {
-    switch (status) {
-        case VCSEC_VehicleLockState_E_VEHICLELOCKSTATE_UNLOCKED:
-        case VCSEC_VehicleLockState_E_VEHICLELOCKSTATE_SELECTIVE_UNLOCKED:
-            return true;
-        case VCSEC_VehicleLockState_E_VEHICLELOCKSTATE_LOCKED:
-        case VCSEC_VehicleLockState_E_VEHICLELOCKSTATE_INTERNAL_LOCKED:
-            return false;
-        default:
-            return std::nullopt;
-    }
-}
-
-std::optional<bool> VehicleStateManager::convert_user_presence(VCSEC_UserPresence_E presence) {
-    switch (presence) {
-        case VCSEC_UserPresence_E_VEHICLE_USER_PRESENCE_PRESENT:
-            return true;
-        case VCSEC_UserPresence_E_VEHICLE_USER_PRESENCE_NOT_PRESENT:
-            return false;
-        default:
-            return std::nullopt;
-    }
-}
-
-std::string VehicleStateManager::get_charging_state_text(const CarServer_ChargeState_ChargingState& state) {
-    switch (state.which_type) {
-        case CarServer_ChargeState_ChargingState_Disconnected_tag: return "Disconnected";
-        case CarServer_ChargeState_ChargingState_NoPower_tag: return "No Power";
-        case CarServer_ChargeState_ChargingState_Starting_tag: return "Starting";
-        case CarServer_ChargeState_ChargingState_Charging_tag: return "Charging";
-        case CarServer_ChargeState_ChargingState_Complete_tag: return "Complete";
-        case CarServer_ChargeState_ChargingState_Stopped_tag: return "Stopped";
-        case CarServer_ChargeState_ChargingState_Calibrating_tag: return "Calibrating";
-        default: return "Unknown";
-    }
-}
-
-bool VehicleStateManager::is_charger_connected_from_state(const CarServer_ChargeState_ChargingState& state) {
-    switch (state.which_type) {
-        case CarServer_ChargeState_ChargingState_Disconnected_tag:
-        case CarServer_ChargeState_ChargingState_Unknown_tag:
-            return false;
-        default:
-            return true;
-    }
-}
-
-std::string VehicleStateManager::get_iec61851_state_text(const CarServer_ChargeState_ChargingState& state) {
-    switch (state.which_type) {
-        case CarServer_ChargeState_ChargingState_Disconnected_tag: return "A";
-        case CarServer_ChargeState_ChargingState_NoPower_tag: return "E";
-        case CarServer_ChargeState_ChargingState_Starting_tag: return "C";
-        case CarServer_ChargeState_ChargingState_Charging_tag: return "C";
-        case CarServer_ChargeState_ChargingState_Complete_tag: return "B";
-        case CarServer_ChargeState_ChargingState_Stopped_tag: return "B";
-        case CarServer_ChargeState_ChargingState_Calibrating_tag: return "C";
-        default: return "F";
-    }
-}
-
-std::string VehicleStateManager::get_shift_state_text(const CarServer_ShiftState& state) {
-    switch (state.which_type) {
-        case CarServer_ShiftState_P_tag: return "P";
-        case CarServer_ShiftState_R_tag: return "R";
-        case CarServer_ShiftState_N_tag: return "N";
-        case CarServer_ShiftState_D_tag: return "D";
-        case CarServer_ShiftState_SNA_tag: return "SNA";
-        case CarServer_ShiftState_Invalid_tag: return "Invalid";
-        default: return "Unknown";
-    }
-}
-
-std::string VehicleStateManager::get_charge_limit_reason_text(const CarServer_ChargeState_ChargeLimitReason& reason) {
-    switch (reason) {
-        case CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonUnknown: return "Unknown";
-        case CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonNone: return "None";
-        case CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonEvse: return "EVSE";
-        case CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonBattTempLow: return "BattTempLow";
-        case CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonHighSoc: return "HighSoc";
-        case CarServer_ChargeState_ChargeLimitReason_ChargeLimitReasonCabin: return "Cabin";
-        default: return "Unknown";
     }
 }
 

--- a/components/tesla_ble_vehicle/vehicle_state_manager.h
+++ b/components/tesla_ble_vehicle/vehicle_state_manager.h
@@ -191,18 +191,7 @@ private:
     
     void set_sensor_available(binary_sensor::BinarySensor* sensor, bool available);
     void set_sensor_available(sensor::Sensor* sensor, bool available);
-    
-    // ==========================================================================
-    // State conversion helpers
-    // ==========================================================================
-    std::optional<bool> convert_sleep_status(VCSEC_VehicleSleepStatus_E status);
-    std::optional<bool> convert_lock_status(VCSEC_VehicleLockState_E status);
-    std::optional<bool> convert_user_presence(VCSEC_UserPresence_E presence);
-    std::string get_charging_state_text(const CarServer_ChargeState_ChargingState& state);
-    bool is_charger_connected_from_state(const CarServer_ChargeState_ChargingState& state);
-    std::string get_iec61851_state_text(const CarServer_ChargeState_ChargingState& state);
-    std::string get_shift_state_text(const CarServer_ShiftState& state);
-    std::string get_charge_limit_reason_text(const CarServer_ChargeState_ChargeLimitReason& reason);
+
 };
 
 } // namespace tesla_ble_vehicle

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Structural consistency checks for the tesla_ble_vehicle codegen.
+
+The component's entities are data-driven: lists of dicts in __init__.py are
+turned into ESPHome entities at build time. This script parses those lists with
+the stdlib `ast` module (no esphome import needed) and checks that every entry
+is well-formed: required keys present, entity ids unique across all lists.
+
+Run locally with:  make test-python   (or just:  make test)
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+COMPONENT = (
+    Path(__file__).resolve().parent.parent
+    / "components" / "tesla_ble_vehicle" / "__init__.py"
+)
+
+ENTITY_LISTS = {
+    "BINARY_SENSORS": {"required": ("id", "name")},
+    "SENSORS": {"required": ("id", "name")},
+    "TEXT_SENSORS": {"required": ("id", "name")},
+    "BUTTONS": {"required": ("id", "name", "class", "setter")},
+    "SWITCHES": {"required": ("id", "name", "class", "setter")},
+}
+
+
+def find_list(tree: ast.Module, name: str):
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name for target in node.targets
+        ):
+            if isinstance(node.value, ast.List):
+                return node.value.elts
+    raise AssertionError(f"list '{name}' not found in {COMPONENT}")
+
+
+def main() -> int:
+    tree = ast.parse(COMPONENT.read_text(encoding="utf-8"), filename=str(COMPONENT))
+
+    checks = 0
+    failures = 0
+    seen_ids = {}
+
+    for list_name, spec in ENTITY_LISTS.items():
+        for entry in find_list(tree, list_name):
+            if not isinstance(entry, ast.Dict):
+                continue
+            keys = {
+                key.value
+                for key in entry.keys
+                if isinstance(key, ast.Constant) and isinstance(key.value, str)
+            }
+
+            for required in spec["required"]:
+                checks += 1
+                if required not in keys:
+                    print(f"  FAIL {list_name}: entry missing required key '{required}'")
+                    failures += 1
+
+            id_node = next(
+                (value for key, value in zip(entry.keys, entry.values)
+                 if isinstance(key, ast.Constant) and key.value == "id"),
+                None,
+            )
+            if isinstance(id_node, ast.Constant) and isinstance(id_node.value, str):
+                entity_id = id_node.value
+                checks += 1
+                if entity_id in seen_ids:
+                    print(f"  FAIL duplicate entity id '{entity_id}' (in {list_name}, "
+                          f"already in {seen_ids[entity_id]})")
+                    failures += 1
+                else:
+                    seen_ids[entity_id] = list_name
+
+    if failures:
+        print(f"FAILED: {failures}/{checks} checks")
+        return 1
+    print(f"OK: {checks} checks passed across {len(ENTITY_LISTS)} entity lists")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_polling_policy.cpp
+++ b/tests/test_polling_policy.cpp
@@ -1,0 +1,213 @@
+// Behavioural tests for InfotainmentPollPolicy (components/tesla_ble_vehicle/
+// polling_policy.h). No ESPHome or tesla-ble dependency - builds with a plain
+// C++ compiler:  make test-cpp  (or just  make test).
+//
+// These tests describe desired behaviour, not implementation details:
+//  - idle cars (including unlocked / user-present) must be allowed to sleep
+//  - only charging and sentry mode keep the car awake
+//  - natural awake blips must not restart the aggressive polling window
+//  - genuine activity after sleep resumes fast, wake-enabled polling
+
+#include <cstdio>
+
+#include "polling_policy.h"
+
+using namespace esphome::tesla_ble_vehicle;
+
+static int g_checks = 0;
+static int g_failures = 0;
+
+#define CHECK(cond)                                                      \
+  do {                                                                   \
+    ++g_checks;                                                          \
+    if (!(cond)) {                                                       \
+      ++g_failures;                                                      \
+      std::printf("  FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);      \
+    }                                                                    \
+  } while (0)
+
+// Defaults used across tests: 30s awake, 10s active, 11 min sleep timeout.
+static void configure(InfotainmentPollPolicy &p) {
+  p.set_awake_interval_ms(30000);
+  p.set_active_interval_ms(10000);
+  p.set_sleep_timeout_ms(660000);
+}
+
+static void test_default_intervals() {
+  InfotainmentPollPolicy p;
+  CHECK(p.update(1000, false, false, false).interval_ms == 30000);
+  CHECK(p.update(1000, false, true, false).interval_ms == 10000);
+  CHECK(p.update(1000, true, false, false).interval_ms == 660000);
+}
+
+static void test_idle_polling_backs_off_after_timeout() {
+  InfotainmentPollPolicy p;
+  configure(p);
+
+  // Fresh connection: an idle car polls gently with WAKE_IF_NEEDED...
+  InfotainmentPollDecision d = p.update(1000, false, false, false);
+  CHECK(d.wake_policy == WakePolicy::WAKE_IF_NEEDED);
+  CHECK(d.interval_ms == 30000);
+
+  // ...for the whole idle window...
+  d = p.update(1000 + 600000, false, false, false);
+  CHECK(d.wake_policy == WakePolicy::WAKE_IF_NEEDED);
+
+  // ...then backs off to NO_WAKE_SKIP so it can fall asleep (#202).
+  d = p.update(1000 + 660000, false, false, false);
+  CHECK(d.wake_policy == WakePolicy::NO_WAKE_SKIP);
+  CHECK(d.interval_ms == 660000);
+}
+
+static void test_observed_asleep_skips_wake_polling() {
+  InfotainmentPollPolicy p;
+  configure(p);
+
+  // Car already asleep: never wake it, poll slowly.
+  InfotainmentPollDecision d = p.update(1000, true, false, false);
+  CHECK(d.wake_policy == WakePolicy::NO_WAKE_SKIP);
+  CHECK(d.interval_ms == 660000);
+}
+
+static void test_charging_keeps_vehicle_awake() {
+  InfotainmentPollPolicy p;
+  configure(p);
+
+  InfotainmentPollDecision d = p.update(1000, false, true, false);
+  CHECK(d.wake_policy == WakePolicy::WAKE_IF_NEEDED);
+  CHECK(d.interval_ms == 10000);
+
+  // Hours later (charging takes a while) still fully awake.
+  d = p.update(1000 + 7200000, false, true, false);
+  CHECK(d.wake_policy == WakePolicy::WAKE_IF_NEEDED);
+  CHECK(d.interval_ms == 10000);
+}
+
+static void test_sentry_mode_keeps_vehicle_awake() {
+  InfotainmentPollPolicy p;
+  configure(p);
+
+  InfotainmentPollDecision d = p.update(1000, false, false, true);
+  CHECK(d.wake_policy == WakePolicy::WAKE_IF_NEEDED);
+  CHECK(d.interval_ms == 10000);
+
+  d = p.update(1000 + 7200000, false, false, true);
+  CHECK(d.wake_policy == WakePolicy::WAKE_IF_NEEDED);
+  CHECK(d.interval_ms == 10000);
+}
+
+static void test_unlocked_or_presence_does_not_keep_awake() {
+  InfotainmentPollPolicy p;
+  configure(p);
+
+  // Left unlocked (or user present because a phone is in range) is not an
+  // active state: the car must still be allowed to fall asleep (#202).
+  p.update(1000, false, false, false);
+  InfotainmentPollDecision d = p.update(1000 + 660000, false, false, false);
+  CHECK(d.wake_policy == WakePolicy::NO_WAKE_SKIP);
+}
+
+static void test_awake_blip_does_not_resume_wake_polling() {
+  InfotainmentPollPolicy p;
+  configure(p);
+
+  p.update(1000, false, false, false);
+  CHECK(p.update(1000 + 660000, false, false, false).wake_policy == WakePolicy::NO_WAKE_SKIP);
+
+  // The car blips awake on its own, then sleeps again. This must NOT restart
+  // the aggressive polling window or it would be re-woken every time (#201).
+  CHECK(p.update(1000 + 700000, false, false, false).wake_policy == WakePolicy::NO_WAKE_SKIP);
+  CHECK(p.update(1000 + 730000, true, false, false).wake_policy == WakePolicy::NO_WAKE_SKIP);
+}
+
+static void test_activity_after_sleep_resumes_fast_polling() {
+  InfotainmentPollPolicy p;
+  configure(p);
+
+  p.update(1000, false, false, false);
+  CHECK(p.update(1000 + 660000, false, false, false).wake_policy == WakePolicy::NO_WAKE_SKIP);
+
+  // Charging starts: immediately back to fast, wake-enabled polling.
+  InfotainmentPollDecision d = p.update(1000 + 700000, false, true, false);
+  CHECK(d.wake_policy == WakePolicy::WAKE_IF_NEEDED);
+  CHECK(d.interval_ms == 10000);
+}
+
+static void test_reset_starts_fresh_idle_window() {
+  InfotainmentPollPolicy p;
+  configure(p);
+
+  p.update(1000, false, false, false);
+  // Reconnect: forget how long the car has been idle.
+  p.reset();
+  InfotainmentPollDecision d = p.update(1000000, false, false, false);
+  CHECK(d.wake_policy == WakePolicy::WAKE_IF_NEEDED);
+  CHECK(d.interval_ms == 30000);
+}
+
+static void test_idle_timeout_counts_from_charging_stop() {
+  InfotainmentPollPolicy p;
+  configure(p);
+
+  // Charging for 2 hours, then charging completes.
+  p.update(1000, false, true, false);
+  p.update(1000 + 7200000, false, true, false);
+  p.update(1000 + 7200000 + 1, false, false, false);
+
+  // The idle window runs from when charging stopped, not from connect:
+  // shortly after the stop we still poll with WAKE_IF_NEEDED...
+  InfotainmentPollDecision d = p.update(1000 + 7200000 + 100000, false, false, false);
+  CHECK(d.wake_policy == WakePolicy::WAKE_IF_NEEDED);
+  CHECK(d.interval_ms == 30000);
+
+  // ...and only after the full timeout from the stop do we back off.
+  d = p.update(1000 + 7200000 + 660000, false, false, false);
+  CHECK(d.wake_policy == WakePolicy::NO_WAKE_SKIP);
+}
+
+static void test_idle_timeout_counts_from_sentry_off() {
+  InfotainmentPollPolicy p;
+  configure(p);
+
+  // Sentry was on overnight, then turned off.
+  p.update(1000, false, false, true);
+  p.update(1000 + 28800000, false, false, true);
+  p.update(1000 + 28800000 + 1, false, false, false);
+
+  InfotainmentPollDecision d = p.update(1000 + 28800000 + 100000, false, false, false);
+  CHECK(d.wake_policy == WakePolicy::WAKE_IF_NEEDED);
+
+  d = p.update(1000 + 28800000 + 660000, false, false, false);
+  CHECK(d.wake_policy == WakePolicy::NO_WAKE_SKIP);
+}
+
+static void test_charging_and_sentry_together_stay_awake() {
+  InfotainmentPollPolicy p;
+  configure(p);
+
+  InfotainmentPollDecision d = p.update(1000, false, true, true);
+  CHECK(d.wake_policy == WakePolicy::WAKE_IF_NEEDED);
+  CHECK(d.interval_ms == 10000);
+}
+
+int main() {
+  test_default_intervals();
+  test_idle_polling_backs_off_after_timeout();
+  test_observed_asleep_skips_wake_polling();
+  test_charging_keeps_vehicle_awake();
+  test_sentry_mode_keeps_vehicle_awake();
+  test_unlocked_or_presence_does_not_keep_awake();
+  test_awake_blip_does_not_resume_wake_polling();
+  test_activity_after_sleep_resumes_fast_polling();
+  test_idle_timeout_counts_from_charging_stop();
+  test_idle_timeout_counts_from_sentry_off();
+  test_charging_and_sentry_together_stay_awake();
+  test_reset_starts_fresh_idle_window();
+
+  if (g_failures > 0) {
+    std::printf("FAILED: %d/%d checks\n", g_failures, g_checks);
+    return 1;
+  }
+  std::printf("OK: %d checks passed\n", g_checks);
+  return 0;
+}

--- a/tests/test_state_text.cpp
+++ b/tests/test_state_text.cpp
@@ -1,0 +1,143 @@
+// Behavioural tests for state_text (components/tesla_ble_vehicle/state_text.h).
+// No ESPHome or tesla-ble dependency - builds with a plain C++ compiler:
+//   make test-cpp  (or just  make test)
+//
+// These tests describe desired behaviour of the raw state -> text/flag
+// conversions that feed the sensors: what each VCSEC/CarServer state maps to.
+
+#include <cstdio>
+
+#include "state_text.h"
+
+using namespace esphome::tesla_ble_vehicle::state_text;
+
+static int g_checks = 0;
+static int g_failures = 0;
+
+#define CHECK(cond)                                                      \
+  do {                                                                   \
+    ++g_checks;                                                          \
+    if (!(cond)) {                                                       \
+      ++g_failures;                                                      \
+      std::printf("  FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);      \
+    }                                                                    \
+  } while (0)
+
+#define CHECK_OPT(opt, expected) CHECK((opt).has_value() && (opt).value() == (expected))
+#define CHECK_STR(actual, expected) CHECK((actual) == (expected))
+
+static void test_sleep_status() {
+  CHECK_OPT(sleep_status(kSleepAwake), false);
+  CHECK_OPT(sleep_status(kSleepAsleep), true);
+  CHECK(!sleep_status(kSleepUnknown).has_value());
+  CHECK(!sleep_status(99).has_value());
+}
+
+static void test_lock_status() {
+  CHECK_OPT(lock_status(kLockUnlocked), true);
+  CHECK_OPT(lock_status(kLockSelectiveUnlocked), true);
+  CHECK_OPT(lock_status(kLockLocked), false);
+  CHECK_OPT(lock_status(kLockInternalLocked), false);
+  CHECK(!lock_status(99).has_value());
+}
+
+static void test_user_presence() {
+  CHECK_OPT(user_presence(kPresencePresent), true);
+  CHECK_OPT(user_presence(kPresenceNotPresent), false);
+  CHECK(!user_presence(kPresenceUnknown).has_value());
+  CHECK(!user_presence(99).has_value());
+}
+
+static void test_is_charging() {
+  CHECK(is_charging(kChargingStateCharging));
+  CHECK(is_charging(kChargingStateStarting));
+  CHECK(!is_charging(kChargingStateComplete));
+  CHECK(!is_charging(kChargingStateStopped));
+  CHECK(!is_charging(kChargingStateDisconnected));
+  CHECK(!is_charging(kChargingStateNoPower));
+  CHECK(!is_charging(kChargingStateUnknown));
+  CHECK(!is_charging(99));
+}
+
+static void test_charging_state_text() {
+  CHECK_STR(charging_state(kChargingStateDisconnected), "Disconnected");
+  CHECK_STR(charging_state(kChargingStateNoPower), "No Power");
+  CHECK_STR(charging_state(kChargingStateStarting), "Starting");
+  CHECK_STR(charging_state(kChargingStateCharging), "Charging");
+  CHECK_STR(charging_state(kChargingStateComplete), "Complete");
+  CHECK_STR(charging_state(kChargingStateStopped), "Stopped");
+  CHECK_STR(charging_state(kChargingStateCalibrating), "Calibrating");
+  CHECK_STR(charging_state(kChargingStateUnknown), "Unknown");
+  CHECK_STR(charging_state(99), "Unknown");
+}
+
+static void test_charger_connected() {
+  CHECK(!charger_connected(kChargingStateDisconnected));
+  CHECK(!charger_connected(kChargingStateUnknown));
+  CHECK(charger_connected(kChargingStateNoPower));
+  CHECK(charger_connected(kChargingStateStarting));
+  CHECK(charger_connected(kChargingStateCharging));
+  CHECK(charger_connected(kChargingStateComplete));
+  CHECK(charger_connected(kChargingStateStopped));
+  CHECK(charger_connected(kChargingStateCalibrating));
+}
+
+static void test_iec61851_state_text() {
+  CHECK_STR(iec61851_state(kChargingStateDisconnected), "A");
+  CHECK_STR(iec61851_state(kChargingStateNoPower), "E");
+  CHECK_STR(iec61851_state(kChargingStateStarting), "C");
+  CHECK_STR(iec61851_state(kChargingStateCharging), "C");
+  CHECK_STR(iec61851_state(kChargingStateCalibrating), "C");
+  CHECK_STR(iec61851_state(kChargingStateComplete), "B");
+  CHECK_STR(iec61851_state(kChargingStateStopped), "B");
+  CHECK_STR(iec61851_state(kChargingStateUnknown), "F");
+  CHECK_STR(iec61851_state(99), "F");
+}
+
+static void test_shift_state_text() {
+  CHECK_STR(shift_state(kShiftP), "P");
+  CHECK_STR(shift_state(kShiftR), "R");
+  CHECK_STR(shift_state(kShiftN), "N");
+  CHECK_STR(shift_state(kShiftD), "D");
+  CHECK_STR(shift_state(kShiftSNA), "SNA");
+  CHECK_STR(shift_state(kShiftInvalid), "Invalid");
+  CHECK_STR(shift_state(99), "Unknown");
+}
+
+static void test_is_parked() {
+  CHECK(is_parked(kShiftP));
+  CHECK(!is_parked(kShiftR));
+  CHECK(!is_parked(kShiftN));
+  CHECK(!is_parked(kShiftD));
+  CHECK(!is_parked(kShiftInvalid));
+}
+
+static void test_charge_limit_reason_text() {
+  CHECK_STR(charge_limit_reason(kLimitNone), "None");
+  CHECK_STR(charge_limit_reason(kLimitEvse), "EVSE");
+  CHECK_STR(charge_limit_reason(kLimitBattTempLow), "BattTempLow");
+  CHECK_STR(charge_limit_reason(kLimitHighSoc), "HighSoc");
+  CHECK_STR(charge_limit_reason(kLimitCabin), "Cabin");
+  CHECK_STR(charge_limit_reason(kLimitUnknown), "Unknown");
+  CHECK_STR(charge_limit_reason(99), "Unknown");
+}
+
+int main() {
+  test_sleep_status();
+  test_lock_status();
+  test_user_presence();
+  test_is_charging();
+  test_charging_state_text();
+  test_charger_connected();
+  test_iec61851_state_text();
+  test_shift_state_text();
+  test_is_parked();
+  test_charge_limit_reason_text();
+
+  if (g_failures > 0) {
+    std::printf("FAILED: %d/%d checks\n", g_failures, g_checks);
+    return 1;
+  }
+  std::printf("OK: %d checks passed\n", g_checks);
+  return 0;
+}


### PR DESCRIPTION
Adds a test framework for the component's core logic so behavior is verified locally and in CI without ESPHome or a device.

- `make test` builds+runs C++ unit tests and Python checks (also wired into CI)
- Extract polling decision logic into dependency-free `polling_policy.h` (`InfotainmentPollPolicy`), removing the inline state machine from `TeslaBLEVehicle::update()` — behavior identical to #213
- Extract state→text/flag conversions into dependency-free `state_text.h`; `VehicleStateManager` delegates to it, with `static_assert`s pinning the duplicated protobuf enum values to the tesla-ble library
- Tests: `tests/test_polling_policy.cpp` (34 checks: sleep/backoff, charging/sentry keep awake, awake-blip, idle-window-from-stop), `tests/test_state_text.cpp` (66 checks), `tests/test_codegen.py` (stdlib-only entity-list consistency)
- No runtime behavior change; firmware still compiles