### PR TITLE
test: extract poll scheduling into InfotainmentPollPolicy and cover it

### DIFF
--- a/components/tesla_ble_vehicle/polling_policy.h
+++ b/components/tesla_ble_vehicle/polling_policy.h
@@ -42,6 +42,16 @@ public:
   // fresh idle window.
   void reset() { idle_since_ms_ = 0; }
 
+  // Whether a poll is due: at least interval_ms has elapsed since the last poll
+  // fired (recorded via on_poll()). Unsigned arithmetic stays correct across
+  // the ~49 day millis() wraparound.
+  bool should_poll(uint32_t now_ms, uint32_t interval_ms) const {
+    return now_ms - last_poll_ms_ >= interval_ms;
+  }
+
+  // Record that a poll fired at now_ms.
+  void on_poll(uint32_t now_ms) { last_poll_ms_ = now_ms; }
+
   InfotainmentPollDecision update(uint32_t now_ms, bool is_asleep, bool is_charging, bool is_sentry_mode) {
     const bool active = is_charging || is_sentry_mode;
     if (active) {
@@ -67,6 +77,7 @@ private:
   uint32_t active_interval_ms_{10000};
   uint32_t sleep_timeout_ms_{660000};
   uint32_t idle_since_ms_{0};
+  uint32_t last_poll_ms_{0};
 };
 
 }  // namespace tesla_ble_vehicle

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -206,7 +206,7 @@ void TeslaBLEVehicle::update() {
       poll_policy_.update(now, is_asleep, state_manager_->is_charging(),
                           state_manager_->is_sentry_mode());
 
-  if (now - last_infotainment_poll_ >= decision.interval_ms) {
+  if (poll_policy_.should_poll(now, decision.interval_ms)) {
     TeslaBLE::WakePolicy policy =
         decision.wake_policy == WakePolicy::NO_WAKE_SKIP
             ? TeslaBLE::WakePolicy::NO_WAKE_SKIP
@@ -216,7 +216,7 @@ void TeslaBLEVehicle::update() {
                  ? "sleeping - NO_WAKE_SKIP"
                  : "active - WAKE_IF_NEEDED");
     vehicle_->infotainment_poll(policy);
-    last_infotainment_poll_ = now;
+    poll_policy_.on_poll(now);
   }
 }
 
@@ -541,14 +541,14 @@ int TeslaBLEVehicle::regenerate_key() {
 
 void TeslaBLEVehicle::force_update() {
   uint32_t now = millis();
-  if (now - last_infotainment_poll_ < poll_policy_.active_interval_ms()) {
+  if (!poll_policy_.should_poll(now, poll_policy_.active_interval_ms())) {
     ESP_LOGD(TAG, "Force update requested too soon (within active polling "
                   "interval) - ignoring");
     return;
   }
 
   ESP_LOGI(TAG, "Force update requested");
-  last_infotainment_poll_ = now;
+  poll_policy_.on_poll(now);
 
   if (vehicle_) {
     vehicle_->vcsec_poll();
@@ -937,7 +937,7 @@ void TeslaBLEVehicle::handle_connection_established() {
     vehicle_->vcsec_poll();
     vehicle_->infotainment_poll(TeslaBLE::WakePolicy::WAKE_IF_NEEDED);
     last_vcsec_poll_ = millis();
-    last_infotainment_poll_ = millis();
+    poll_policy_.on_poll(millis());
     poll_policy_.reset();
   }
 
@@ -955,7 +955,7 @@ void TeslaBLEVehicle::handle_connection_lost() {
   if (ble_adapter_)
     ble_adapter_->clear_queues();
 
-  last_infotainment_poll_ = 0;
+  poll_policy_.on_poll(0);
   last_vcsec_poll_ = 0;
   poll_policy_.reset();
   this->status_set_warning("BLE connection lost");

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -189,7 +189,6 @@ private:
     
     // Polling state
     uint32_t last_vcsec_poll_{0};
-    uint32_t last_infotainment_poll_{0};
     InfotainmentPollPolicy poll_policy_;
 
     // BLE state

--- a/tests/test_polling_policy.cpp
+++ b/tests/test_polling_policy.cpp
@@ -190,6 +190,76 @@ static void test_charging_and_sentry_together_stay_awake() {
   CHECK(d.interval_ms == 10000);
 }
 
+// --- poll scheduling (should_poll / on_poll) ---
+
+static void test_poll_due_when_no_poll_fired_yet() {
+  InfotainmentPollPolicy p;
+  configure(p);
+  // last_poll_ms_ starts 0 and millis() is long past the interval after boot:
+  // the first tick is immediately due.
+  CHECK(p.should_poll(50000, 30000));
+  p.on_poll(50000);
+  CHECK(!p.should_poll(50000 + 10000, 30000));
+}
+
+static void test_poll_due_after_interval() {
+  InfotainmentPollPolicy p;
+  configure(p);
+  p.on_poll(1000);
+  CHECK(!p.should_poll(1000 + 29999, 30000));
+  CHECK(p.should_poll(1000 + 30000, 30000));
+}
+
+static void test_poll_tracks_fire_time() {
+  InfotainmentPollPolicy p;
+  configure(p);
+  p.on_poll(1000);
+  // fires again on the next cadence
+  CHECK(p.should_poll(1000 + 30000, 30000));
+  p.on_poll(1000 + 30000);
+  CHECK(!p.should_poll(1000 + 30000 + 1000, 30000));
+}
+
+static void test_force_update_throttled_to_active_interval() {
+  InfotainmentPollPolicy p;
+  configure(p);
+  p.on_poll(1000);
+  // force_update is throttled to the active interval
+  CHECK(!p.should_poll(1000 + 5000, p.active_interval_ms()));
+  CHECK(p.should_poll(1000 + 10000, p.active_interval_ms()));
+}
+
+static void test_poll_stays_correct_across_millis_wraparound() {
+  InfotainmentPollPolicy p;
+  configure(p);
+  // Last poll 10s before the ~49 day millis() wraparound.
+  const uint32_t last_poll = 0xFFFFFFFFu - 10000u;
+  p.on_poll(last_poll);
+  // After the wrap, elapsed time still counts correctly.
+  CHECK(!p.should_poll(5000, 30000));      // elapsed 15s < 30s
+  CHECK(p.should_poll(30000, 30000));      // elapsed 40s >= 30s
+}
+
+static void test_full_tick_cadence_while_charging() {
+  InfotainmentPollPolicy p;
+  configure(p);
+
+  // t=20000: charging; nothing fired yet, so the first poll is due immediately.
+  InfotainmentPollDecision d = p.update(20000, false, true, false);
+  CHECK(d.interval_ms == 10000);
+  CHECK(p.should_poll(20000, d.interval_ms));
+  p.on_poll(20000);
+
+  // t=20000+5000: within the 10s active interval, no poll.
+  d = p.update(20000 + 5000, false, true, false);
+  CHECK(d.interval_ms == 10000);
+  CHECK(!p.should_poll(20000 + 5000, d.interval_ms));
+
+  // t=20000+10000: due again.
+  d = p.update(20000 + 10000, false, true, false);
+  CHECK(p.should_poll(20000 + 10000, d.interval_ms));
+}
+
 int main() {
   test_default_intervals();
   test_idle_polling_backs_off_after_timeout();
@@ -203,6 +273,12 @@ int main() {
   test_idle_timeout_counts_from_sentry_off();
   test_charging_and_sentry_together_stay_awake();
   test_reset_starts_fresh_idle_window();
+  test_poll_due_when_no_poll_fired_yet();
+  test_poll_due_after_interval();
+  test_poll_tracks_fire_time();
+  test_force_update_throttled_to_active_interval();
+  test_poll_stays_correct_across_millis_wraparound();
+  test_full_tick_cadence_while_charging();
 
   if (g_failures > 0) {
     std::printf("FAILED: %d/%d checks\n", g_failures, g_checks);


### PR DESCRIPTION
Moves the infotainment poll scheduler into the pure, unit-testable `InfotainmentPollPolicy` (adding `should_poll`/`on_poll`), so the "does a poll actually fire this tick" behavior is no longer untested. No runtime behavior change.

- `update()`, `force_update()`, and the connect/disconnect handlers use `should_poll`/`on_poll`; the `last_infotainment_poll_` member is removed
- new tests: due on first tick, fires exactly at interval, force-update throttled to the active interval, millis() wraparound (~49 days) stays correct, full charging cadence