### PR TITLE
chore: bump tesla-ble to v5.1.2

### DIFF
--- a/packages/board.yml
+++ b/packages/board.yml
@@ -7,4 +7,4 @@ esp32:
     components:
       - name: tesla-ble
         source: https://github.com/yoziru/tesla-ble.git
-        ref: v5.1.1
+        ref: v5.1.2


### PR DESCRIPTION
Bumps the tesla-ble external component from v5.1.1 to [v5.1.2](https://github.com/yoziru/tesla-ble/releases/tag/v5.1.2).

Upstream changes:
- fix: resolve `-Wformat` and unused-function compiler warnings (yoziru/tesla-ble#76) — removes xtensa build warnings originating from `managed_components/tesla-ble/`
- chore: sync standalone-build mbedtls pin to 3.6.6-idf (yoziru/tesla-ble#77, ESP-IDF builds unaffected)
- update protobuf @f97fa1e4 (yoziru/tesla-ble#78): adds generated types for parental controls vehicle actions