### PR TITLE
fix: force reconnect when GATT link is up but vehicle session is down

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -87,6 +87,7 @@ TEST_CXXFLAGS ?= -std=c++17 -Wall -Wextra
 
 # Each tests/test_*.cpp compiles to its own binary.
 TEST_BINS := \
+  $(TEST_BUILD_DIR)/test_connection_reset_policy \
   $(TEST_BUILD_DIR)/test_polling_policy \
   $(TEST_BUILD_DIR)/test_state_text
 

--- a/components/tesla_ble_vehicle/connection_reset_policy.h
+++ b/components/tesla_ble_vehicle/connection_reset_policy.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <cstdint>
+
+namespace esphome {
+namespace tesla_ble_vehicle {
+
+// Detects a wedged BLE link: the GATT connection is ESTABLISHED but the
+// TeslaBLE Vehicle reports disconnected. This happens when the library's
+// auth-stuck watchdog resets connection state (reset_all_sessions_and_connection_
+// -> set_connected(false)) while the GATT link stays up: ble_client keeps the
+// healthy-looking connection open indefinitely, and only a fresh connect
+// cycle re-runs service discovery and notify registration - the only path
+// that restores Vehicle connectivity (handle_connection_established).
+//
+// Pure logic with no ESPHome or tesla-ble dependency so it can be unit-tested
+// in isolation (see tests/test_connection_reset_policy.cpp).
+//
+// Behaviour:
+//  - a mismatch must persist for a grace window before triggering, because
+//    service discovery and notify registration legitimately take a moment
+//    after ESTABLISHED
+//  - after a forced reconnect, re-arm only after a cooldown so a genuinely
+//    sick radio/link does not churn connections
+//  - restored connectivity clears mismatch tracking; a later mismatch needs
+//    a fresh grace window
+class ConnectionResetPolicy {
+ public:
+  void set_mismatch_grace_ms(uint32_t grace_ms) { mismatch_grace_ms_ = grace_ms; }
+  void set_retrigger_cooldown_ms(uint32_t cooldown_ms) { retrigger_cooldown_ms_ = cooldown_ms; }
+
+  uint32_t mismatch_grace_ms() const { return mismatch_grace_ms_; }
+  uint32_t retrigger_cooldown_ms() const { return retrigger_cooldown_ms_; }
+
+  // Forget all timing state, e.g. on (re)connect teardown.
+  void reset() {
+    mismatch_since_ms_ = 0;
+    last_trigger_ms_ = 0;
+  }
+
+  // Whether the link should be force-cycled now. Call every loop iteration.
+  // Unsigned arithmetic stays correct across the ~49 day millis() wraparound.
+  bool should_force_reconnect(uint32_t now_ms, bool gatt_established, bool vehicle_connected) {
+    if (!gatt_established || vehicle_connected) {
+      mismatch_since_ms_ = 0;
+      return false;
+    }
+    if (last_trigger_ms_ != 0 && now_ms - last_trigger_ms_ < retrigger_cooldown_ms_) {
+      return false;
+    }
+    if (mismatch_since_ms_ == 0) {
+      mismatch_since_ms_ = now_ms;
+      return false;
+    }
+    return now_ms - mismatch_since_ms_ >= mismatch_grace_ms_;
+  }
+
+  // Record that a forced reconnect fired at now_ms.
+  void on_force_reconnect(uint32_t now_ms) {
+    last_trigger_ms_ = now_ms;
+    mismatch_since_ms_ = 0;
+  }
+
+ private:
+  static constexpr uint32_t DEFAULT_MISMATCH_GRACE_MS = 20000;
+  static constexpr uint32_t DEFAULT_RETRIGGER_COOLDOWN_MS = 60000;
+
+  uint32_t mismatch_grace_ms_{DEFAULT_MISMATCH_GRACE_MS};
+  uint32_t retrigger_cooldown_ms_{DEFAULT_RETRIGGER_COOLDOWN_MS};
+  uint32_t mismatch_since_ms_{0};
+  uint32_t last_trigger_ms_{0};
+};
+
+}  // namespace tesla_ble_vehicle
+}  // namespace esphome

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -180,6 +180,18 @@ void TeslaBLEVehicle::loop() {
     vehicle_->loop();
   if (ble_adapter_)
     ble_adapter_->process_write_queue();
+
+  // Detect a wedged link: GATT established but the Vehicle reports
+  // disconnected (e.g. after the library's auth-stuck watchdog reset session
+  // state). Only a fresh connect cycle re-runs service discovery and notify
+  // registration, so force one instead of waiting for a reboot.
+  const bool gatt_established = is_connected();
+  const bool vehicle_connected = vehicle_ != nullptr && vehicle_->is_connected();
+  if (connection_reset_policy_.should_force_reconnect(millis(), gatt_established, vehicle_connected)) {
+    ESP_LOGW(TAG, "GATT connection up but vehicle is disconnected - forcing reconnect");
+    connection_reset_policy_.on_force_reconnect(millis());
+    this->parent()->disconnect();
+  }
 }
 
 void TeslaBLEVehicle::update() {

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -20,6 +20,7 @@
 
 #include "ble_adapter_impl.h"
 #include "polling_policy.h"
+#include "connection_reset_policy.h"
 #include "storage_adapter_impl.h"
 #include <vehicle.h>
 #include "vehicle_state_manager.h"
@@ -190,6 +191,7 @@ private:
     // Polling state
     uint32_t last_vcsec_poll_{0};
     InfotainmentPollPolicy poll_policy_;
+    ConnectionResetPolicy connection_reset_policy_;
 
     // BLE state
     espbt::ESPBTUUID service_uuid_;

--- a/packages/board.yml
+++ b/packages/board.yml
@@ -7,4 +7,4 @@ esp32:
     components:
       - name: tesla-ble
         source: https://github.com/yoziru/tesla-ble.git
-        ref: v5.1.1
+        ref: v5.1.2

--- a/tests/test_connection_reset_policy.cpp
+++ b/tests/test_connection_reset_policy.cpp
@@ -1,0 +1,146 @@
+// Behavioural tests for ConnectionResetPolicy (components/tesla_ble_vehicle/
+// connection_reset_policy.h). No ESPHome or tesla-ble dependency - builds with
+// a plain C++ compiler:  make test-cpp  (or just  make test).
+//
+// The policy detects a wedged BLE link: the GATT connection is ESTABLISHED but
+// the TeslaBLE Vehicle reports disconnected (e.g. after the library's
+// auth-stuck watchdog reset connection state while the link stayed up). In
+// that state nothing else cycles the link - only a fresh connect cycle re-runs
+// service discovery / notify registration, which restores Vehicle
+// connectivity.
+//
+// Scenarios covered:
+//  - normal operation and normal (re)connect sequences must never force a
+//    disconnect
+//  - a genuinely wedged link forces exactly one reconnect after a grace
+//    period, then backs off before trying again
+//  - connectivity blips restart the grace window
+
+#include <cstdio>
+
+#include "connection_reset_policy.h"
+
+using namespace esphome::tesla_ble_vehicle;
+
+static int g_checks = 0;
+static int g_failures = 0;
+
+#define CHECK(cond)                                                      \
+  do {                                                                   \
+    ++g_checks;                                                          \
+    if (!(cond)) {                                                       \
+      ++g_failures;                                                      \
+      std::printf("  FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);      \
+    }                                                                    \
+  } while (0)
+
+static void test_healthy_link_never_triggers() {
+  ConnectionResetPolicy p;
+  for (uint32_t t = 0; t <= 300000; t += 5000) {
+    CHECK(!p.should_force_reconnect(t, true, true));
+  }
+}
+
+static void test_no_gatt_link_never_triggers() {
+  ConnectionResetPolicy p;
+  // Nothing to fix while there is no GATT connection at all - ble_client owns
+  // scanning/connecting in that state.
+  for (uint32_t t = 0; t <= 300000; t += 5000) {
+    CHECK(!p.should_force_reconnect(t, false, false));
+  }
+}
+
+static void test_normal_connect_sequence_does_not_trigger() {
+  ConnectionResetPolicy p;
+  // Realistic bring-up: physical link established first, service discovery +
+  // notify registration follow, only then does Vehicle report connected. The
+  // temporary mismatch must ride out the grace window.
+  CHECK(!p.should_force_reconnect(0, false, false));
+  CHECK(!p.should_force_reconnect(2000, true, false));   // ESTABLISHED, discovery running
+  CHECK(!p.should_force_reconnect(8000, true, false));   // still registering notifications
+  CHECK(!p.should_force_reconnect(9000, true, true));    // fully up
+
+  // ...and stays quiet afterwards.
+  for (uint32_t t = 10000; t <= 120000; t += 5000) {
+    CHECK(!p.should_force_reconnect(t, true, true));
+  }
+}
+
+static void test_slow_but_successful_setup_does_not_trigger() {
+  ConnectionResetPolicy p;
+  // A slow car/radio that takes most of the grace window is still fine as
+  // long as connectivity lands before it expires.
+  CHECK(!p.should_force_reconnect(10000, true, false));
+  CHECK(!p.should_force_reconnect(25000, true, false));
+  CHECK(!p.should_force_reconnect(28000, true, true));
+}
+
+static void test_wedged_link_triggers_once_then_backs_off() {
+  ConnectionResetPolicy p;
+  // Wedge begins at t=1000 and never heals on its own.
+  CHECK(!p.should_force_reconnect(1000, true, false));
+
+  uint32_t fired_at = 0;
+  for (uint32_t t = 6000; t <= 120000; t += 2000) {
+    if (p.should_force_reconnect(t, true, false)) {
+      fired_at = t;
+      break;
+    }
+    CHECK(t < 60000);  // must fire within about a minute, not hang forever
+  }
+  CHECK(fired_at != 0);
+  p.on_force_reconnect(fired_at);
+
+  // After forcing, stay quiet for a substantial cool-off even though the
+  // mismatch persists (the forced cycle needs time to play out)...
+  for (uint32_t t = fired_at + 2000; t < fired_at + 45000; t += 2000) {
+    CHECK(!p.should_force_reconnect(t, true, false));
+  }
+
+  // ...but if the wedge survives the retry, we do try again eventually.
+  bool refired = false;
+  for (uint32_t t = fired_at + 45000; t <= fired_at + 300000; t += 2000) {
+    if (p.should_force_reconnect(t, true, false)) {
+      refired = true;
+      break;
+    }
+  }
+  CHECK(refired);
+}
+
+static void test_connectivity_blip_restarts_the_window() {
+  ConnectionResetPolicy p;
+  // Mismatch starts...
+  CHECK(!p.should_force_reconnect(1000, true, false));
+  // ...connectivity briefly restores mid-grace...
+  CHECK(!p.should_force_reconnect(8000, true, true));
+  // ...then the wedge returns. The observation window restarts: it should not
+  // fire immediately just because the earlier mismatch had already run a while.
+  CHECK(!p.should_force_reconnect(9000, true, false));
+  CHECK(!p.should_force_reconnect(15000, true, false));
+
+  uint32_t fired_at = 0;
+  for (uint32_t t = 16000; t <= 90000; t += 1000) {
+    if (p.should_force_reconnect(t, true, false)) {
+      fired_at = t;
+      break;
+    }
+  }
+  CHECK(fired_at != 0);
+}
+
+int main() {
+  test_healthy_link_never_triggers();
+  test_no_gatt_link_never_triggers();
+  test_normal_connect_sequence_does_not_trigger();
+  test_slow_but_successful_setup_does_not_trigger();
+  test_wedged_link_triggers_once_then_backs_off();
+  test_connectivity_blip_restarts_the_window();
+
+  if (g_failures > 0) {
+    std::printf("FAILED: %d/%d checks\n", g_failures, g_checks);
+    return 1;
+  }
+  std::printf("OK: %d checks passed\n", g_checks);
+  return 0;
+}


### PR DESCRIPTION
## Problem
Devices could wedge permanently until reboot: the tesla-ble library's auth-stuck watchdog (`reset_all_sessions_and_connection_`, triggered when a VCSEC/infotainment handshake stalls >30s - e.g. weak BLE signal) sets `Vehicle::is_connected = false` **while the GATT link stays up**. Nothing cycled the link in that state:

- commands are rejected ("Not connected")
- only a fresh connect cycle re-runs service discovery + notify registration, which is the sole path that calls `set_connected(true)` again
- `ble_client` keeps a healthy-looking connection open indefinitely

Matches the field reports: stall after a while / must restart to work / weak-signal install needed reflash.

## Fix
Add `ConnectionResetPolicy` (pure logic, unit-tested like `InfotainmentPollPolicy`) and check it every `loop()`:

- if GATT is `ESTABLISHED` but Vehicle reports disconnected for longer than a 20s grace window → force `parent()->disconnect()`; `ble_client` reconnects from advertisements and normal bring-up restores the session
- grace window ensures normal connect sequences (discovery, notify registration) are never interrupted
- 60s cooldown before re-triggering so genuinely sick radios don't churn connections; each retry gets its own fresh window

## Tests
`tests/test_connection_reset_policy.cpp` covers: healthy link never triggers, no-GATT never triggers, normal/slow-but-successful bring-up never triggers, wedged link fires once then backs off, connectivity blips restart the window. Written against the desired behaviour before implementation.

## Verification
- `make test-cpp`: all suites pass (190 new checks)
- Full firmware compile for m5stack-nanoc6 passes