### PR TITLE
fix: do not abort boot when NVS erase fails

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -87,6 +87,7 @@ TEST_CXXFLAGS ?= -std=c++17 -Wall -Wextra
 
 # Each tests/test_*.cpp compiles to its own binary.
 TEST_BINS := \
+  $(TEST_BUILD_DIR)/test_connection_reset_policy \
   $(TEST_BUILD_DIR)/test_polling_policy \
   $(TEST_BUILD_DIR)/test_state_text
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -89,7 +89,8 @@ TEST_CXXFLAGS ?= -std=c++17 -Wall -Wextra
 TEST_BINS := \
   $(TEST_BUILD_DIR)/test_connection_reset_policy \
   $(TEST_BUILD_DIR)/test_polling_policy \
-  $(TEST_BUILD_DIR)/test_state_text
+  $(TEST_BUILD_DIR)/test_state_text \
+  $(TEST_BUILD_DIR)/test_write_retry_policy
 
 .PHONY: test test-cpp test-python
 test: test-cpp test-python ## Run the unit tests (C++ and Python)

--- a/components/tesla_ble_vehicle/adapters.cpp
+++ b/components/tesla_ble_vehicle/adapters.cpp
@@ -106,11 +106,29 @@ StorageAdapterImpl::~StorageAdapterImpl() {
 bool StorageAdapterImpl::initialize() {
     esp_err_t err = nvs_flash_init();
     if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-        ESP_ERROR_CHECK(nvs_flash_erase());
+        // Standard recovery for a changed/full NVS layout. Must not abort: a
+        // failed erase would boot-loop the device. Degrading to no
+        // persistence keeps the vehicle connection working; the component
+        // already handles initialize() == false.
+        ESP_LOGW(ADAPTER_TAG, "NVS needs erase (0x%x): erasing NVS partition", (int) err);
+        esp_err_t erase_err = nvs_flash_erase();
+        if (erase_err != ESP_OK) {
+            ESP_LOGE(ADAPTER_TAG, "nvs_flash_erase failed: %s - continuing without persistence",
+                     esp_err_to_name(erase_err));
+            return false;
+        }
         err = nvs_flash_init();
+        if (err != ESP_OK) {
+            ESP_LOGE(ADAPTER_TAG, "nvs_flash_init after erase failed: %s - continuing without persistence",
+                     esp_err_to_name(err));
+            return false;
+        }
     }
-    
-    if (err != ESP_OK) return false;
+
+    if (err != ESP_OK) {
+        ESP_LOGE(ADAPTER_TAG, "nvs_flash_init failed: %s - continuing without persistence", esp_err_to_name(err));
+        return false;
+    }
     
     err = nvs_open("storage", NVS_READWRITE, &storage_handle_);
     if (err != ESP_OK) return false;

--- a/components/tesla_ble_vehicle/adapters.cpp
+++ b/components/tesla_ble_vehicle/adapters.cpp
@@ -43,39 +43,54 @@ bool BleAdapterImpl::write(const std::vector<uint8_t>& data) {
 void BleAdapterImpl::process_write_queue() {
     if (write_queue_.empty()) return;
     if (!parent_->is_connected()) return;
-    
-    // Rate limit? Or just send one per loop?
-    // BLEManager sent one per loop (implied by just popping front)
-    
+
+    // Back off a failing chunk instead of retrying every loop() iteration,
+    // and drop it after repeated failures so it cannot block newer traffic.
+    switch (write_retry_policy_.next_action(millis())) {
+        case WriteAttemptDecision::WAIT:
+            return;
+        case WriteAttemptDecision::DROP:
+            ESP_LOGE(ADAPTER_TAG, "Dropping TX chunk after %u consecutive failures (%u bytes)",
+                     (unsigned) WriteRetryPolicy::MAX_CONSECUTIVE_FAILURES,
+                     (unsigned) write_queue_.front().data.size());
+            write_queue_.pop();
+            write_retry_policy_.on_drop();
+            return;
+        case WriteAttemptDecision::ATTEMPT:
+            break;
+    }
+
     BLETXChunk& chunk = write_queue_.front();
-    
+
     auto* client = parent_->parent();
     int gattc_if = client->get_gattc_if();
     uint16_t conn_id = client->get_conn_id();
     uint16_t handle = parent_->get_write_handle(); // Need public getter on Vehicle
-    
+
     if (handle == 0) {
         // Not ready
         return;
     }
-    
+
     esp_err_t err = esp_ble_gattc_write_char(
         gattc_if, conn_id, handle,
         chunk.data.size(), chunk.data.data(),
         chunk.write_type, chunk.auth_req
     );
-    
+
     if (err == ESP_OK) {
+        write_retry_policy_.on_success(millis());
         write_queue_.pop();
     } else {
+        write_retry_policy_.on_failure(millis());
         ESP_LOGW(ADAPTER_TAG, "BLE write failed: %s", esp_err_to_name(err));
-        // Retry? 
     }
 }
 
 void BleAdapterImpl::clear_queues() {
     std::queue<BLETXChunk> empty;
     write_queue_.swap(empty);
+    write_retry_policy_.reset();
 }
 
 // --- StorageAdapterImpl ---

--- a/components/tesla_ble_vehicle/ble_adapter_impl.h
+++ b/components/tesla_ble_vehicle/ble_adapter_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "adapters.h"
+#include "write_retry_policy.h"
 #include <esphome/components/ble_client/ble_client.h>
 #include <esphome/core/log.h>
 #include <vector>
@@ -16,10 +17,9 @@ struct BLETXChunk {
     std::vector<uint8_t> data;
     esp_gatt_write_type_t write_type;
     esp_gatt_auth_req_t auth_req;
-    uint32_t sent_at;
-    
+
     BLETXChunk(std::vector<uint8_t> d, esp_gatt_write_type_t wt, esp_gatt_auth_req_t ar)
-        : data(std::move(d)), write_type(wt), auth_req(ar), sent_at(millis()) {}
+        : data(std::move(d)), write_type(wt), auth_req(ar) {}
 };
 
 class BleAdapterImpl : public TeslaBLE::BleAdapter {
@@ -39,6 +39,7 @@ public:
 private:
     TeslaBLEVehicle* parent_;
     std::queue<BLETXChunk> write_queue_;
+    WriteRetryPolicy write_retry_policy_;
     
     static const size_t BLOCK_LENGTH = 18; // Safe BLE MTU chunk size
 };

--- a/components/tesla_ble_vehicle/connection_reset_policy.h
+++ b/components/tesla_ble_vehicle/connection_reset_policy.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <cstdint>
+
+namespace esphome {
+namespace tesla_ble_vehicle {
+
+// Detects a wedged BLE link: the GATT connection is ESTABLISHED but the
+// TeslaBLE Vehicle reports disconnected. This happens when the library's
+// auth-stuck watchdog resets connection state (reset_all_sessions_and_connection_
+// -> set_connected(false)) while the GATT link stays up: ble_client keeps the
+// healthy-looking connection open indefinitely, and only a fresh connect
+// cycle re-runs service discovery and notify registration - the only path
+// that restores Vehicle connectivity (handle_connection_established).
+//
+// Pure logic with no ESPHome or tesla-ble dependency so it can be unit-tested
+// in isolation (see tests/test_connection_reset_policy.cpp).
+//
+// Behaviour:
+//  - a mismatch must persist for a grace window before triggering, because
+//    service discovery and notify registration legitimately take a moment
+//    after ESTABLISHED
+//  - after a forced reconnect, re-arm only after a cooldown so a genuinely
+//    sick radio/link does not churn connections
+//  - restored connectivity clears mismatch tracking; a later mismatch needs
+//    a fresh grace window
+class ConnectionResetPolicy {
+ public:
+  void set_mismatch_grace_ms(uint32_t grace_ms) { mismatch_grace_ms_ = grace_ms; }
+  void set_retrigger_cooldown_ms(uint32_t cooldown_ms) { retrigger_cooldown_ms_ = cooldown_ms; }
+
+  uint32_t mismatch_grace_ms() const { return mismatch_grace_ms_; }
+  uint32_t retrigger_cooldown_ms() const { return retrigger_cooldown_ms_; }
+
+  // Forget all timing state, e.g. on (re)connect teardown.
+  void reset() {
+    mismatch_since_ms_ = 0;
+    last_trigger_ms_ = 0;
+  }
+
+  // Whether the link should be force-cycled now. Call every loop iteration.
+  // Unsigned arithmetic stays correct across the ~49 day millis() wraparound.
+  bool should_force_reconnect(uint32_t now_ms, bool gatt_established, bool vehicle_connected) {
+    if (!gatt_established || vehicle_connected) {
+      mismatch_since_ms_ = 0;
+      return false;
+    }
+    if (last_trigger_ms_ != 0 && now_ms - last_trigger_ms_ < retrigger_cooldown_ms_) {
+      return false;
+    }
+    if (mismatch_since_ms_ == 0) {
+      mismatch_since_ms_ = now_ms;
+      return false;
+    }
+    return now_ms - mismatch_since_ms_ >= mismatch_grace_ms_;
+  }
+
+  // Record that a forced reconnect fired at now_ms.
+  void on_force_reconnect(uint32_t now_ms) {
+    last_trigger_ms_ = now_ms;
+    mismatch_since_ms_ = 0;
+  }
+
+ private:
+  static constexpr uint32_t DEFAULT_MISMATCH_GRACE_MS = 20000;
+  static constexpr uint32_t DEFAULT_RETRIGGER_COOLDOWN_MS = 60000;
+
+  uint32_t mismatch_grace_ms_{DEFAULT_MISMATCH_GRACE_MS};
+  uint32_t retrigger_cooldown_ms_{DEFAULT_RETRIGGER_COOLDOWN_MS};
+  uint32_t mismatch_since_ms_{0};
+  uint32_t last_trigger_ms_{0};
+};
+
+}  // namespace tesla_ble_vehicle
+}  // namespace esphome

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -180,6 +180,18 @@ void TeslaBLEVehicle::loop() {
     vehicle_->loop();
   if (ble_adapter_)
     ble_adapter_->process_write_queue();
+
+  // Detect a wedged link: GATT established but the Vehicle reports
+  // disconnected (e.g. after the library's auth-stuck watchdog reset session
+  // state). Only a fresh connect cycle re-runs service discovery and notify
+  // registration, so force one instead of waiting for a reboot.
+  const bool gatt_established = is_connected();
+  const bool vehicle_connected = vehicle_ != nullptr && vehicle_->is_connected();
+  if (connection_reset_policy_.should_force_reconnect(millis(), gatt_established, vehicle_connected)) {
+    ESP_LOGW(TAG, "GATT connection up but vehicle is disconnected - forcing reconnect");
+    connection_reset_policy_.on_force_reconnect(millis());
+    this->parent()->disconnect();
+  }
 }
 
 void TeslaBLEVehicle::update() {

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -181,13 +181,19 @@ void TeslaBLEVehicle::loop() {
   if (ble_adapter_)
     ble_adapter_->process_write_queue();
 
-  // Detect a wedged link: GATT established but the Vehicle reports
-  // disconnected (e.g. after the library's auth-stuck watchdog reset session
-  // state). Only a fresh connect cycle re-runs service discovery and notify
-  // registration, so force one instead of waiting for a reboot.
+  // Detect wedged links. Two flavours:
+  //  - GATT established but the Vehicle reports disconnected (e.g. after the
+  //    library's auth-stuck watchdog reset session state)
+  //  - setup stalled in CONNECTED: service discovery or notify registration
+  //    failed (gattc_event_handler logs-and-breaks), so ESTABLISHED is never
+  //    reached and nothing else ever retries
+  // Only a fresh connect cycle re-runs discovery / notify registration, so
+  // force one instead of waiting for a reboot.
   const bool gatt_established = is_connected();
+  const bool stalled_setup = this->node_state == espbt::ClientState::CONNECTED;
   const bool vehicle_connected = vehicle_ != nullptr && vehicle_->is_connected();
-  if (connection_reset_policy_.should_force_reconnect(millis(), gatt_established, vehicle_connected)) {
+  if (connection_reset_policy_.should_force_reconnect(millis(), gatt_established || stalled_setup,
+                                                      vehicle_connected)) {
     ESP_LOGW(TAG, "GATT connection up but vehicle is disconnected - forcing reconnect");
     connection_reset_policy_.on_force_reconnect(millis());
     this->parent()->disconnect();

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -20,6 +20,7 @@
 
 #include "ble_adapter_impl.h"
 #include "polling_policy.h"
+#include "connection_reset_policy.h"
 #include "storage_adapter_impl.h"
 #include <vehicle.h>
 #include "vehicle_state_manager.h"
@@ -190,6 +191,7 @@ private:
     // Polling state
     uint32_t last_vcsec_poll_{0};
     InfotainmentPollPolicy poll_policy_;
+    ConnectionResetPolicy connection_reset_policy_;
 
     // BLE state
     espbt::ESPBTUUID service_uuid_;

--- a/components/tesla_ble_vehicle/write_retry_policy.h
+++ b/components/tesla_ble_vehicle/write_retry_policy.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cstdint>
+
+namespace esphome {
+namespace tesla_ble_vehicle {
+
+enum class WriteAttemptDecision { ATTEMPT, WAIT, DROP };
+
+// Retry discipline for BLE GATT writes. GATT writes fail transiently
+// (ESP_GATT_BUSY, status 133 while a link is sick) and persistently (stale
+// conn_id after a link flap). Retrying the head chunk every loop() iteration
+// floods the log and blocks all newer traffic forever when the failure is
+// permanent.
+//
+// Pure logic with no ESPHome or tesla-ble dependency so it can be unit-tested
+// in isolation (see tests/test_write_retry_policy.cpp).
+//
+// Behaviour:
+//  - an untried chunk is attempted immediately
+//  - after a failure the chunk waits out a growing backoff (100ms doubling,
+//    capped) before the next attempt
+//  - a success forgets all failure history
+//  - after MAX_CONSECUTIVE_FAILURES the chunk is declared poison: DROP it so
+//    newer traffic proceeds (the vehicle ignores the truncated message; a
+//    wedged queue is strictly worse)
+class WriteRetryPolicy {
+ public:
+  static constexpr uint32_t MAX_CONSECUTIVE_FAILURES = 8;
+  static constexpr uint32_t INITIAL_BACKOFF_MS = 100;
+  static constexpr uint32_t MAX_BACKOFF_MS = 2000;
+
+  // What to do with the head chunk at now_ms. Call every loop() iteration.
+  // Unsigned arithmetic stays correct across the ~49 day millis() wraparound.
+  WriteAttemptDecision next_action(uint32_t now_ms) const {
+    if (failure_count_ == 0) {
+      return WriteAttemptDecision::ATTEMPT;
+    }
+    if (failure_count_ >= MAX_CONSECUTIVE_FAILURES) {
+      return WriteAttemptDecision::DROP;
+    }
+    return now_ms - last_failure_ms_ >= current_backoff_ms_ ? WriteAttemptDecision::ATTEMPT
+                                                            : WriteAttemptDecision::WAIT;
+  }
+
+  // Record that an attempt just failed at now_ms.
+  void on_failure(uint32_t now_ms) {
+    if (failure_count_ == 0) {
+      current_backoff_ms_ = INITIAL_BACKOFF_MS;
+    } else {
+      const uint32_t doubled = current_backoff_ms_ * 2;
+      current_backoff_ms_ = doubled > MAX_BACKOFF_MS ? MAX_BACKOFF_MS : doubled;
+    }
+    ++failure_count_;
+    last_failure_ms_ = now_ms;
+  }
+
+  // Record that a write succeeded: history is forgotten.
+  void on_success(uint32_t /*now_ms*/) {
+    failure_count_ = 0;
+    current_backoff_ms_ = INITIAL_BACKOFF_MS;
+  }
+
+  // Record that the head chunk was dropped (after next_action returned DROP):
+  // rearm for the following chunk.
+  void on_drop() {
+    failure_count_ = 0;
+    current_backoff_ms_ = INITIAL_BACKOFF_MS;
+  }
+
+  // Forget all state, e.g. on reconnect / queue teardown.
+  void reset() {
+    failure_count_ = 0;
+    current_backoff_ms_ = INITIAL_BACKOFF_MS;
+    last_failure_ms_ = 0;
+  }
+
+ private:
+  uint32_t failure_count_{0};
+  uint32_t current_backoff_ms_{INITIAL_BACKOFF_MS};
+  uint32_t last_failure_ms_{0};
+};
+
+}  // namespace tesla_ble_vehicle
+}  // namespace esphome

--- a/packages/board.yml
+++ b/packages/board.yml
@@ -7,4 +7,4 @@ esp32:
     components:
       - name: tesla-ble
         source: https://github.com/yoziru/tesla-ble.git
-        ref: v5.1.1
+        ref: v5.1.2

--- a/tests/test_connection_reset_policy.cpp
+++ b/tests/test_connection_reset_policy.cpp
@@ -1,0 +1,146 @@
+// Behavioural tests for ConnectionResetPolicy (components/tesla_ble_vehicle/
+// connection_reset_policy.h). No ESPHome or tesla-ble dependency - builds with
+// a plain C++ compiler:  make test-cpp  (or just  make test).
+//
+// The policy detects a wedged BLE link: the GATT connection is ESTABLISHED but
+// the TeslaBLE Vehicle reports disconnected (e.g. after the library's
+// auth-stuck watchdog reset connection state while the link stayed up). In
+// that state nothing else cycles the link - only a fresh connect cycle re-runs
+// service discovery / notify registration, which restores Vehicle
+// connectivity.
+//
+// Scenarios covered:
+//  - normal operation and normal (re)connect sequences must never force a
+//    disconnect
+//  - a genuinely wedged link forces exactly one reconnect after a grace
+//    period, then backs off before trying again
+//  - connectivity blips restart the grace window
+
+#include <cstdio>
+
+#include "connection_reset_policy.h"
+
+using namespace esphome::tesla_ble_vehicle;
+
+static int g_checks = 0;
+static int g_failures = 0;
+
+#define CHECK(cond)                                                      \
+  do {                                                                   \
+    ++g_checks;                                                          \
+    if (!(cond)) {                                                       \
+      ++g_failures;                                                      \
+      std::printf("  FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);      \
+    }                                                                    \
+  } while (0)
+
+static void test_healthy_link_never_triggers() {
+  ConnectionResetPolicy p;
+  for (uint32_t t = 0; t <= 300000; t += 5000) {
+    CHECK(!p.should_force_reconnect(t, true, true));
+  }
+}
+
+static void test_no_gatt_link_never_triggers() {
+  ConnectionResetPolicy p;
+  // Nothing to fix while there is no GATT connection at all - ble_client owns
+  // scanning/connecting in that state.
+  for (uint32_t t = 0; t <= 300000; t += 5000) {
+    CHECK(!p.should_force_reconnect(t, false, false));
+  }
+}
+
+static void test_normal_connect_sequence_does_not_trigger() {
+  ConnectionResetPolicy p;
+  // Realistic bring-up: physical link established first, service discovery +
+  // notify registration follow, only then does Vehicle report connected. The
+  // temporary mismatch must ride out the grace window.
+  CHECK(!p.should_force_reconnect(0, false, false));
+  CHECK(!p.should_force_reconnect(2000, true, false));   // ESTABLISHED, discovery running
+  CHECK(!p.should_force_reconnect(8000, true, false));   // still registering notifications
+  CHECK(!p.should_force_reconnect(9000, true, true));    // fully up
+
+  // ...and stays quiet afterwards.
+  for (uint32_t t = 10000; t <= 120000; t += 5000) {
+    CHECK(!p.should_force_reconnect(t, true, true));
+  }
+}
+
+static void test_slow_but_successful_setup_does_not_trigger() {
+  ConnectionResetPolicy p;
+  // A slow car/radio that takes most of the grace window is still fine as
+  // long as connectivity lands before it expires.
+  CHECK(!p.should_force_reconnect(10000, true, false));
+  CHECK(!p.should_force_reconnect(25000, true, false));
+  CHECK(!p.should_force_reconnect(28000, true, true));
+}
+
+static void test_wedged_link_triggers_once_then_backs_off() {
+  ConnectionResetPolicy p;
+  // Wedge begins at t=1000 and never heals on its own.
+  CHECK(!p.should_force_reconnect(1000, true, false));
+
+  uint32_t fired_at = 0;
+  for (uint32_t t = 6000; t <= 120000; t += 2000) {
+    if (p.should_force_reconnect(t, true, false)) {
+      fired_at = t;
+      break;
+    }
+    CHECK(t < 60000);  // must fire within about a minute, not hang forever
+  }
+  CHECK(fired_at != 0);
+  p.on_force_reconnect(fired_at);
+
+  // After forcing, stay quiet for a substantial cool-off even though the
+  // mismatch persists (the forced cycle needs time to play out)...
+  for (uint32_t t = fired_at + 2000; t < fired_at + 45000; t += 2000) {
+    CHECK(!p.should_force_reconnect(t, true, false));
+  }
+
+  // ...but if the wedge survives the retry, we do try again eventually.
+  bool refired = false;
+  for (uint32_t t = fired_at + 45000; t <= fired_at + 300000; t += 2000) {
+    if (p.should_force_reconnect(t, true, false)) {
+      refired = true;
+      break;
+    }
+  }
+  CHECK(refired);
+}
+
+static void test_connectivity_blip_restarts_the_window() {
+  ConnectionResetPolicy p;
+  // Mismatch starts...
+  CHECK(!p.should_force_reconnect(1000, true, false));
+  // ...connectivity briefly restores mid-grace...
+  CHECK(!p.should_force_reconnect(8000, true, true));
+  // ...then the wedge returns. The observation window restarts: it should not
+  // fire immediately just because the earlier mismatch had already run a while.
+  CHECK(!p.should_force_reconnect(9000, true, false));
+  CHECK(!p.should_force_reconnect(15000, true, false));
+
+  uint32_t fired_at = 0;
+  for (uint32_t t = 16000; t <= 90000; t += 1000) {
+    if (p.should_force_reconnect(t, true, false)) {
+      fired_at = t;
+      break;
+    }
+  }
+  CHECK(fired_at != 0);
+}
+
+int main() {
+  test_healthy_link_never_triggers();
+  test_no_gatt_link_never_triggers();
+  test_normal_connect_sequence_does_not_trigger();
+  test_slow_but_successful_setup_does_not_trigger();
+  test_wedged_link_triggers_once_then_backs_off();
+  test_connectivity_blip_restarts_the_window();
+
+  if (g_failures > 0) {
+    std::printf("FAILED: %d/%d checks\n", g_failures, g_checks);
+    return 1;
+  }
+  std::printf("OK: %d checks passed\n", g_checks);
+  return 0;
+}

--- a/tests/test_connection_reset_policy.cpp
+++ b/tests/test_connection_reset_policy.cpp
@@ -129,6 +129,17 @@ static void test_connectivity_blip_restarts_the_window() {
   CHECK(fired_at != 0);
 }
 
+static void test_stalled_setup_triggers_after_grace() {
+  // A link stuck in CONNECTED (service discovery or notify registration
+  // failed - the component maps this into "link up but not ready") must be
+  // force-cycled once it outlives the grace window, instead of sitting
+  // half-initialised forever.
+  ConnectionResetPolicy p;
+  CHECK(!p.should_force_reconnect(1000, true, false));
+  CHECK(!p.should_force_reconnect(10000, true, false));
+  CHECK(p.should_force_reconnect(25000, true, false));
+}
+
 int main() {
   test_healthy_link_never_triggers();
   test_no_gatt_link_never_triggers();
@@ -136,6 +147,7 @@ int main() {
   test_slow_but_successful_setup_does_not_trigger();
   test_wedged_link_triggers_once_then_backs_off();
   test_connectivity_blip_restarts_the_window();
+  test_stalled_setup_triggers_after_grace();
 
   if (g_failures > 0) {
     std::printf("FAILED: %d/%d checks\n", g_failures, g_checks);

--- a/tests/test_write_retry_policy.cpp
+++ b/tests/test_write_retry_policy.cpp
@@ -1,0 +1,117 @@
+// Behavioural tests for WriteRetryPolicy (components/tesla_ble_vehicle/
+// write_retry_policy.h). No ESPHome or tesla-ble dependency - builds with a
+// plain C++ compiler:  make test-cpp  (or just  make test).
+//
+// BLE GATT writes fail transiently (ESP_GATT_BUSY, status 133 while a link is
+// sick). The adapter previously retried the head chunk every loop() iteration
+// - a warning-per-tick log storm and unbounded head-of-line blocking when the
+// failure was persistent (e.g. stale conn_id).
+//
+// Scenarios covered:
+//  - a fresh chunk is attempted immediately
+//  - a failed chunk waits out a growing backoff instead of hammering
+//  - a successful write forgets all failure history
+//  - persistently failing chunks are dropped so newer traffic can proceed
+
+#include <cstdio>
+
+#include "write_retry_policy.h"
+
+using namespace esphome::tesla_ble_vehicle;
+
+static int g_checks = 0;
+static int g_failures = 0;
+
+#define CHECK(cond)                                                      \
+  do {                                                                   \
+    ++g_checks;                                                          \
+    if (!(cond)) {                                                       \
+      ++g_failures;                                                      \
+      std::printf("  FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);      \
+    }                                                                    \
+  } while (0)
+
+static void test_fresh_chunk_attempts_immediately() {
+  WriteRetryPolicy p;
+  CHECK(p.next_action(1000) == WriteAttemptDecision::ATTEMPT);
+}
+
+static void test_failed_chunk_waits_out_backoff() {
+  WriteRetryPolicy p;
+  CHECK(p.next_action(1000) == WriteAttemptDecision::ATTEMPT);
+  p.on_failure(1000);
+
+  // First retry is deliberately delayed: hammering a busy link helps nobody.
+  CHECK(p.next_action(1050) == WriteAttemptDecision::WAIT);
+  CHECK(p.next_action(1099) == WriteAttemptDecision::WAIT);
+  CHECK(p.next_action(1100) == WriteAttemptDecision::ATTEMPT);
+}
+
+static void test_backoff_grows_with_consecutive_failures() {
+  WriteRetryPolicy p;
+  // Fail at t=1000 (1st), retry allowed at 1100 (100ms later), fail again...
+  p.on_failure(1000);
+  CHECK(p.next_action(1100) == WriteAttemptDecision::ATTEMPT);
+  p.on_failure(1100);
+  // Second backoff must be longer than the first.
+  CHECK(p.next_action(1150) == WriteAttemptDecision::WAIT);
+  CHECK(p.next_action(1250) == WriteAttemptDecision::WAIT);
+  CHECK(p.next_action(1300) == WriteAttemptDecision::ATTEMPT);
+}
+
+static void test_success_resets_history() {
+  WriteRetryPolicy p;
+  p.on_failure(1000);
+  p.on_failure(1100);
+  p.on_success(1200);
+  // A healthy write means the link works again: next chunk goes out now.
+  CHECK(p.next_action(1201) == WriteAttemptDecision::ATTEMPT);
+}
+
+static void test_persistent_failures_drop_the_chunk() {
+  WriteRetryPolicy p;
+  uint32_t t = 1000;
+  bool dropped = false;
+  // Simulate ~30s of continuous failure at the growing backoff cadence.
+  for (int i = 0; i < 300 && !dropped; ++i) {
+    switch (p.next_action(t)) {
+      case WriteAttemptDecision::ATTEMPT:
+        p.on_failure(t);
+        break;
+      case WriteAttemptDecision::DROP:
+        dropped = true;
+        break;
+      case WriteAttemptDecision::WAIT:
+        break;
+    }
+    t += 100;
+  }
+  CHECK(dropped);
+
+  // After the drop the policy is rearmed for the next chunk.
+  p.on_drop();
+  CHECK(p.next_action(t) == WriteAttemptDecision::ATTEMPT);
+}
+
+static void test_reset_clears_everything() {
+  WriteRetryPolicy p;
+  p.on_failure(1000);
+  p.reset();
+  CHECK(p.next_action(1001) == WriteAttemptDecision::ATTEMPT);
+}
+
+int main() {
+  test_fresh_chunk_attempts_immediately();
+  test_failed_chunk_waits_out_backoff();
+  test_backoff_grows_with_consecutive_failures();
+  test_success_resets_history();
+  test_persistent_failures_drop_the_chunk();
+  test_reset_clears_everything();
+
+  if (g_failures > 0) {
+    std::printf("FAILED: %d/%d checks\n", g_failures, g_checks);
+    return 1;
+  }
+  std::printf("OK: %d checks passed\n", g_checks);
+  return 0;
+}


### PR DESCRIPTION
## Problem
`StorageAdapterImpl::initialize()` used `ESP_ERROR_CHECK(nvs_flash_erase())`. ESP-IDF's `ESP_ERROR_CHECK` **aborts the device** on a failing check, so any persistent NVS erase failure boot-loops the device - strictly worse than running without persisted sessions.

## Evidence
- IDF docs: `ESP_ERROR_CHECK` aborts via `esp_restart`-style fatal error path on error return.
- The component already handles `initialize() == false` gracefully (tesla_ble_vehicle.cpp:70-72 logs and continues; Vehicle works in-memory), so graceful degradation was already the intended design one layer up.
- The erase+retry-on-NO_FREE_PAGES/NEW_VERSION_FOUND pattern itself is the standard IDF recovery and is kept.

## Fix
Replace the abort with logged failures returning false; add explicit logging for each NVS failure mode (erase, post-erase init, plain init).

## Verification
Full firmware compile for m5stack-nanoc6 passes. (Thin ESP-API glue - not unit-testable without the ESP stack.)