### PR TITLE
chore: bump tesla-ble to v5.1.3

### DIFF
--- a/packages/board.yml
+++ b/packages/board.yml
@@ -7,4 +7,4 @@ esp32:
     components:
       - name: tesla-ble
         source: https://github.com/yoziru/tesla-ble.git
-        ref: v5.1.2
+        ref: v5.1.3


### PR DESCRIPTION
Bumps the tesla-ble external component from v5.1.2 to [v5.1.3](https://github.com/yoziru/tesla-ble/releases/tag/v5.1.3).

Includes (since v5.1.2):
- fix: resync session on counter replay instead of failing (#79) — clears the "commands stop working until vehicle state changes" deadloop
- fix: accept stored sessions whose clock_time is ahead of the local clock (#80) — stored sessions no longer rejected after a reboot before time resync

Together with the component-side fixes already on main (#221 wedge reconnect, #222 TX backoff, #223 stalled-setup reconnect, #224 NVS no-abort, #225 format warnings), this is the batch for device testing.