### PR TITLE
fix: reconcile control state after commands

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -88,6 +88,7 @@ TEST_CXXFLAGS ?= -std=c++17 -Wall -Wextra
 # Each tests/test_*.cpp compiles to its own binary.
 TEST_BINS := \
   $(TEST_BUILD_DIR)/test_connection_reset_policy \
+  $(TEST_BUILD_DIR)/test_control_state_policy \
   $(TEST_BUILD_DIR)/test_polling_policy \
   $(TEST_BUILD_DIR)/test_state_text \
   $(TEST_BUILD_DIR)/test_write_retry_policy
@@ -101,7 +102,7 @@ test-cpp: $(TEST_BINS) ## Build and run the C++ unit tests
 	  $$bin || exit 1; \
 	done
 
-$(TEST_BUILD_DIR)/test_%: $(TEST_DIR)/test_%.cpp components/tesla_ble_vehicle/polling_policy.h components/tesla_ble_vehicle/state_text.h
+$(TEST_BUILD_DIR)/test_%: $(TEST_DIR)/test_%.cpp components/tesla_ble_vehicle/control_state_policy.h components/tesla_ble_vehicle/polling_policy.h components/tesla_ble_vehicle/state_text.h
 	mkdir -p $(TEST_BUILD_DIR)
 	$(CXX) $(TEST_CXXFLAGS) $(TEST_INCLUDE_DIRS) $< -o $@
 

--- a/components/tesla_ble_vehicle/control_state_policy.h
+++ b/components/tesla_ble_vehicle/control_state_policy.h
@@ -1,0 +1,45 @@
+#pragma once
+
+namespace esphome {
+namespace tesla_ble_vehicle {
+
+enum class ControlStateCommand {
+  CHARGING_STATE,
+  SET_AMPS,
+  SET_LIMIT,
+  SET_STEERING_WHEEL_HEAT,
+  SET_SENTRY_MODE,
+};
+
+enum class ControlStateRefresh { NONE, CHARGE_STATE, CLIMATE_STATE, CLOSURES_STATE };
+
+struct ControlStateDecision {
+  bool publish_requested_state;
+  bool republish_confirmed_number_state;
+  ControlStateRefresh refresh;
+};
+
+inline ControlStateDecision control_state_decision(ControlStateCommand command,
+                                                    bool command_succeeded) {
+  if (!command_succeeded) {
+    const bool is_number_command = command == ControlStateCommand::SET_AMPS ||
+                                   command == ControlStateCommand::SET_LIMIT;
+    return {false, is_number_command, ControlStateRefresh::NONE};
+  }
+
+  switch (command) {
+    case ControlStateCommand::CHARGING_STATE:
+    case ControlStateCommand::SET_AMPS:
+    case ControlStateCommand::SET_LIMIT:
+      return {true, false, ControlStateRefresh::CHARGE_STATE};
+    case ControlStateCommand::SET_STEERING_WHEEL_HEAT:
+      return {true, false, ControlStateRefresh::CLIMATE_STATE};
+    case ControlStateCommand::SET_SENTRY_MODE:
+      return {true, false, ControlStateRefresh::CLOSURES_STATE};
+  }
+
+  return {false, false, ControlStateRefresh::NONE};
+}
+
+}  // namespace tesla_ble_vehicle
+}  // namespace esphome

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -479,8 +479,9 @@ void TeslaBLEVehicle::set_force_update_button(button::Button *button) {
 // Command tracking (v5.1.0 OperationResult + phase callbacks)
 // =============================================================================
 
-void TeslaBLEVehicle::handle_command_result(TeslaBLE::OperationResult result) {
-  std::string value = last_command_name_;
+void TeslaBLEVehicle::handle_command_result(const std::string &name,
+                                            TeslaBLE::OperationResult result) {
+  std::string value = name;
 
   if (result.is_success()) {
     value += " → Success";
@@ -506,19 +507,56 @@ void TeslaBLEVehicle::send_command_with_tracking(
     UniversalMessage_Domain domain,
     const std::string &name,
     std::function<int(TeslaBLE::Client *, uint8_t *, size_t *)> builder,
-    TeslaBLE::WakePolicy wake_policy) {
+    TeslaBLE::WakePolicy wake_policy, std::function<void(bool)> on_result) {
   if (!vehicle_) {
     ESP_LOGE(TAG, "Cannot send command '%s': vehicle not initialized", name.c_str());
     return;
   }
 
-  last_command_name_ = name;
   vehicle_->send_command_result(
       domain, name, std::move(builder),
-      [this](TeslaBLE::OperationResult result) {
-        handle_command_result(std::move(result));
+      [this, name, on_result = std::move(on_result)](TeslaBLE::OperationResult result) {
+        const bool succeeded = result.is_success();
+        handle_command_result(name, std::move(result));
+        if (on_result) on_result(succeeded);
       },
       wake_policy);
+}
+
+void TeslaBLEVehicle::schedule_state_refresh_(ControlStateRefresh refresh) {
+  if (!vehicle_ || refresh == ControlStateRefresh::NONE) return;
+
+  const char *timeout_name = nullptr;
+  switch (refresh) {
+    case ControlStateRefresh::CHARGE_STATE:
+      timeout_name = "charge-state-refresh";
+      break;
+    case ControlStateRefresh::CLIMATE_STATE:
+      timeout_name = "climate-state-refresh";
+      break;
+    case ControlStateRefresh::CLOSURES_STATE:
+      timeout_name = "closures-state-refresh";
+      break;
+    case ControlStateRefresh::NONE:
+      return;
+  }
+
+  this->set_timeout(timeout_name, 1500, [this, refresh]() {
+    if (!vehicle_ || !vehicle_->is_connected()) return;
+    switch (refresh) {
+      case ControlStateRefresh::CHARGE_STATE:
+        vehicle_->charge_state_poll(TeslaBLE::WakePolicy::NO_WAKE_SKIP);
+        break;
+      case ControlStateRefresh::CLIMATE_STATE:
+        vehicle_->climate_state_poll(TeslaBLE::WakePolicy::NO_WAKE_SKIP);
+        break;
+      case ControlStateRefresh::CLOSURES_STATE:
+        vehicle_->closures_state_poll(TeslaBLE::WakePolicy::NO_WAKE_SKIP);
+        break;
+      case ControlStateRefresh::NONE:
+        break;
+    }
+  });
 }
 
 // =============================================================================
@@ -615,6 +653,11 @@ int TeslaBLEVehicle::set_charging_state(bool charging) {
       [charging](TeslaBLE::Client *client, uint8_t *buff, size_t *len) {
         return client->build_car_server_vehicle_action_message(
             buff, len, CarServer_VehicleAction_chargingStartStopAction_tag, &charging);
+      }, TeslaBLE::WakePolicy::WAKE_IF_NEEDED,
+      [this, charging](bool succeeded) {
+        const auto decision = control_state_decision(ControlStateCommand::CHARGING_STATE, succeeded);
+        if (decision.publish_requested_state && state_manager_) state_manager_->update_charging_control_state(charging);
+        schedule_state_refresh_(decision.refresh);
       });
   return 0;
 }
@@ -640,6 +683,12 @@ int TeslaBLEVehicle::set_charging_amps(int amps) {
       [clamped](TeslaBLE::Client *client, uint8_t *buff, size_t *len) {
         return client->build_car_server_vehicle_action_message(
             buff, len, CarServer_VehicleAction_setChargingAmpsAction_tag, &clamped);
+      }, TeslaBLE::WakePolicy::WAKE_IF_NEEDED,
+      [this, clamped](bool succeeded) {
+        const auto decision = control_state_decision(ControlStateCommand::SET_AMPS, succeeded);
+        if (decision.publish_requested_state && state_manager_) state_manager_->update_charging_amps(static_cast<float>(clamped));
+        if (decision.republish_confirmed_number_state && state_manager_) state_manager_->republish_charging_amps();
+        schedule_state_refresh_(decision.refresh);
       });
   return clamped;
 }
@@ -657,6 +706,12 @@ int TeslaBLEVehicle::set_charging_limit(int limit) {
       [limit](TeslaBLE::Client *client, uint8_t *buff, size_t *len) {
         return client->build_car_server_vehicle_action_message(
             buff, len, CarServer_VehicleAction_chargingSetLimitAction_tag, &limit);
+      }, TeslaBLE::WakePolicy::WAKE_IF_NEEDED,
+      [this, limit](bool succeeded) {
+        const auto decision = control_state_decision(ControlStateCommand::SET_LIMIT, succeeded);
+        if (decision.publish_requested_state && state_manager_) state_manager_->update_charging_limit(static_cast<float>(limit));
+        if (decision.republish_confirmed_number_state && state_manager_) state_manager_->republish_charging_limit();
+        schedule_state_refresh_(decision.refresh);
       });
   return 0;
 }
@@ -827,6 +882,11 @@ void TeslaBLEVehicle::set_steering_wheel_heat(bool enable) {
       [enable](TeslaBLE::Client *client, uint8_t *buff, size_t *len) {
         return client->build_car_server_vehicle_action_message(
             buff, len, CarServer_VehicleAction_hvacSteeringWheelHeaterAction_tag, &enable);
+      }, TeslaBLE::WakePolicy::WAKE_IF_NEEDED,
+      [this, enable](bool succeeded) {
+        const auto decision = control_state_decision(ControlStateCommand::SET_STEERING_WHEEL_HEAT, succeeded);
+        if (decision.publish_requested_state && state_manager_) state_manager_->update_steering_wheel_heat(enable);
+        schedule_state_refresh_(decision.refresh);
       });
 }
 
@@ -862,6 +922,11 @@ void TeslaBLEVehicle::set_sentry_mode(bool enable) {
       [enable](TeslaBLE::Client *client, uint8_t *buff, size_t *len) {
         return client->build_car_server_vehicle_action_message(
             buff, len, CarServer_VehicleAction_vehicleControlSetSentryModeAction_tag, &enable);
+      }, TeslaBLE::WakePolicy::WAKE_IF_NEEDED,
+      [this, enable](bool succeeded) {
+        const auto decision = control_state_decision(ControlStateCommand::SET_SENTRY_MODE, succeeded);
+        if (decision.publish_requested_state && state_manager_) state_manager_->update_sentry_mode(enable);
+        schedule_state_refresh_(decision.refresh);
       });
 }
 
@@ -1020,8 +1085,7 @@ void TeslaChargingAmpsNumber::control(float value) {
     return;
   }
 
-  int clamped = parent_->set_charging_amps(static_cast<int>(value));
-  publish_state(static_cast<float>(clamped));
+  parent_->set_charging_amps(static_cast<int>(value));
 }
 
 void TeslaChargingLimitNumber::control(float value) {
@@ -1037,7 +1101,6 @@ void TeslaChargingLimitNumber::control(float value) {
   }
 
   parent_->set_charging_limit(static_cast<int>(value));
-  publish_state(value);
 }
 
 // =============================================================================

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -20,6 +20,7 @@
 #include <esphome/core/preferences.h>
 
 #include "ble_adapter_impl.h"
+#include "control_state_policy.h"
 #include "polling_policy.h"
 #include "connection_reset_policy.h"
 #include "storage_adapter_impl.h"
@@ -241,15 +242,16 @@ private:
     void save_charging_amps_max_(int max);
 
     // Command tracking
-    void handle_command_result(TeslaBLE::OperationResult result);
+    void handle_command_result(const std::string &name, TeslaBLE::OperationResult result);
+    void schedule_state_refresh_(ControlStateRefresh refresh);
     void send_command_with_tracking(
         UniversalMessage_Domain domain,
         const std::string &name,
         std::function<int(TeslaBLE::Client *, uint8_t *, size_t *)> builder,
-        TeslaBLE::WakePolicy wake_policy = TeslaBLE::WakePolicy::WAKE_IF_NEEDED);
+        TeslaBLE::WakePolicy wake_policy = TeslaBLE::WakePolicy::WAKE_IF_NEEDED,
+        std::function<void(bool)> on_result = nullptr);
 
     text_sensor::TextSensor *last_command_sensor_{nullptr};
-    std::string last_command_name_;
 
     // Friends
     friend class VehicleStateManager;
@@ -296,7 +298,7 @@ DEFINE_TESLA_BUTTON(TeslaUnlatchDriverDoorButton, unlatch_driver_door)
  * @brief Generic Tesla switch base that calls a parent method on state change
  * 
  * Each switch type is defined using the DEFINE_TESLA_SWITCH macro below.
- * The macro generates a switch that calls parent->Method(state) and publishes state.
+ * The vehicle method publishes state only after the command result succeeds.
  */
 class TeslaSwitchBase : public switch_::Switch {
 public:
@@ -305,17 +307,23 @@ protected:
     TeslaBLEVehicle *parent_{nullptr};
 };
 
-// Macro to define a Tesla switch that calls a specific parent method with bool state
+// Macro to define a Tesla switch that calls a specific parent method with bool state.
 #define DEFINE_TESLA_SWITCH(ClassName, ParentMethod) \
     class ClassName : public TeslaSwitchBase { \
     protected: \
         void write_state(bool state) override { \
-            if (parent_) { parent_->ParentMethod(state); publish_state(state); } \
+            if (parent_) parent_->ParentMethod(state); \
         } \
     };
 
 // Define all switch types using the macro
-DEFINE_TESLA_SWITCH(TeslaChargingSwitch, set_charging_state)
+class TeslaChargingSwitch : public TeslaSwitchBase {
+ protected:
+  void write_state(bool state) override {
+    if (parent_) parent_->set_charging_state(state);
+  }
+};
+
 DEFINE_TESLA_SWITCH(TeslaSteeringWheelHeatSwitch, set_steering_wheel_heat)
 DEFINE_TESLA_SWITCH(TeslaSentryModeSwitch, set_sentry_mode)
 

--- a/components/tesla_ble_vehicle/vehicle_state_manager.cpp
+++ b/components/tesla_ble_vehicle/vehicle_state_manager.cpp
@@ -344,7 +344,7 @@ void VehicleStateManager::update_charge_state(const CarServer_ChargeState& charg
     // Update charge limit
     if (charge_state.which_optional_charge_limit_soc && charging_limit_number_) {
         const float limit = static_cast<float>(charge_state.optional_charge_limit_soc.charge_limit_soc);
-        publish_sensor_state(charging_limit_number_, limit);
+        update_charging_limit(limit);
     }
     
     // Update charge port door cover (physical door open/closed)
@@ -607,6 +607,34 @@ void VehicleStateManager::update_charge_flap_open(bool open) {
 void VehicleStateManager::update_charging_amps(float amps) {
     ESP_LOGD(STATE_MANAGER_TAG, "Charging amps setpoint from vehicle: %.1f A", amps);
     publish_sensor_state(charging_amps_number_, amps);
+}
+
+void VehicleStateManager::update_charging_limit(float limit) {
+    publish_sensor_state(charging_limit_number_, limit);
+}
+
+void VehicleStateManager::update_charging_control_state(bool charging) {
+    publish_sensor_state(charging_switch_, charging);
+}
+
+void VehicleStateManager::update_steering_wheel_heat(bool enabled) {
+    publish_sensor_state(steering_wheel_heat_switch_, enabled);
+}
+
+void VehicleStateManager::update_sentry_mode(bool enabled) {
+    publish_sensor_state(sentry_mode_switch_, enabled);
+}
+
+void VehicleStateManager::republish_charging_amps() {
+    if (charging_amps_number_ != nullptr && charging_amps_number_->has_state()) {
+        charging_amps_number_->publish_state(charging_amps_number_->state);
+    }
+}
+
+void VehicleStateManager::republish_charging_limit() {
+    if (charging_limit_number_ != nullptr && charging_limit_number_->has_state()) {
+        charging_limit_number_->publish_state(charging_limit_number_->state);
+    }
 }
 
 void VehicleStateManager::update_charger_connected(bool connected) {

--- a/components/tesla_ble_vehicle/vehicle_state_manager.h
+++ b/components/tesla_ble_vehicle/vehicle_state_manager.h
@@ -112,6 +112,12 @@ public:
     void update_user_present(bool present);
     void update_charge_flap_open(bool open);
     void update_charging_amps(float amps);
+    void update_charging_limit(float limit);
+    void update_charging_control_state(bool charging);
+    void update_steering_wheel_heat(bool enabled);
+    void update_sentry_mode(bool enabled);
+    void republish_charging_amps();
+    void republish_charging_limit();
     void update_charger_connected(bool connected);
     
     // ==========================================================================

--- a/tests/test_control_state_policy.cpp
+++ b/tests/test_control_state_policy.cpp
@@ -1,0 +1,72 @@
+#include <cstdio>
+#include <initializer_list>
+
+#include "control_state_policy.h"
+
+using namespace esphome::tesla_ble_vehicle;
+
+static int g_checks = 0;
+static int g_failures = 0;
+
+#define CHECK(cond)                                                      \
+  do {                                                                   \
+    ++g_checks;                                                          \
+    if (!(cond)) {                                                       \
+      ++g_failures;                                                      \
+      std::printf("  FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);    \
+    }                                                                    \
+  } while (0)
+
+static void test_failed_commands_do_not_change_control_state() {
+  for (const auto command : {ControlStateCommand::CHARGING_STATE,
+                             ControlStateCommand::SET_AMPS,
+                             ControlStateCommand::SET_LIMIT,
+                             ControlStateCommand::SET_STEERING_WHEEL_HEAT,
+                             ControlStateCommand::SET_SENTRY_MODE}) {
+    const auto decision = control_state_decision(command, false);
+    CHECK(!decision.publish_requested_state);
+    CHECK(decision.refresh == ControlStateRefresh::NONE);
+  }
+}
+
+static void test_failed_number_commands_republish_the_last_confirmed_state() {
+  CHECK(!control_state_decision(ControlStateCommand::CHARGING_STATE, false)
+             .republish_confirmed_number_state);
+  CHECK(control_state_decision(ControlStateCommand::SET_AMPS, false)
+            .republish_confirmed_number_state);
+  CHECK(control_state_decision(ControlStateCommand::SET_LIMIT, false)
+            .republish_confirmed_number_state);
+}
+
+static void test_successful_commands_publish_and_refresh_authoritative_state() {
+  const struct {
+    ControlStateCommand command;
+    ControlStateRefresh refresh;
+  } cases[] = {
+      {ControlStateCommand::CHARGING_STATE, ControlStateRefresh::CHARGE_STATE},
+      {ControlStateCommand::SET_AMPS, ControlStateRefresh::CHARGE_STATE},
+      {ControlStateCommand::SET_LIMIT, ControlStateRefresh::CHARGE_STATE},
+      {ControlStateCommand::SET_STEERING_WHEEL_HEAT, ControlStateRefresh::CLIMATE_STATE},
+      {ControlStateCommand::SET_SENTRY_MODE, ControlStateRefresh::CLOSURES_STATE},
+  };
+
+  for (const auto &test : cases) {
+    const auto decision = control_state_decision(test.command, true);
+    CHECK(decision.publish_requested_state);
+    CHECK(!decision.republish_confirmed_number_state);
+    CHECK(decision.refresh == test.refresh);
+  }
+}
+
+int main() {
+  test_failed_commands_do_not_change_control_state();
+  test_failed_number_commands_republish_the_last_confirmed_state();
+  test_successful_commands_publish_and_refresh_authoritative_state();
+
+  if (g_failures > 0) {
+    std::printf("FAILED: %d/%d checks\n", g_failures, g_checks);
+    return 1;
+  }
+  std::printf("OK: %d checks passed\n", g_checks);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- publish charging, sentry, and steering controls only after command success
- reconcile each control with a targeted no-wake state poll
- restore failed number writes to their last confirmed state
- share the charging start/stop reconciliation policy

## Verification
- make test
- make compile BOARD=m5stack-nanoc6