### PR TITLE
fix: persist vehicle charging amps max

### DIFF
--- a/components/tesla_ble_vehicle/__init__.py
+++ b/components/tesla_ble_vehicle/__init__.py
@@ -71,6 +71,7 @@ SetChargingLimitAction = tesla_ble_vehicle_ns.class_("SetChargingLimitAction", a
 # Configuration constants
 CONF_VIN = "vin"
 CONF_CHARGING_AMPS_MAX = "charging_amps_max"
+DEFAULT_CHARGING_AMPS_MAX = 32
 CONF_ROLE = "role"
 
 # Polling configuration constants
@@ -243,7 +244,7 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(CONF_ID): cv.declare_id(TeslaBLEVehicle),
             cv.Required(CONF_VIN): cv.string,
-            cv.Optional(CONF_CHARGING_AMPS_MAX, default=32): cv.int_range(min=1, max=48),
+            cv.Optional(CONF_CHARGING_AMPS_MAX, default=DEFAULT_CHARGING_AMPS_MAX): cv.int_range(min=1, max=48),
             cv.Optional(CONF_ROLE, default="DRIVER"): cv.enum(TESLA_ROLES, upper=True),
             # Polling intervals (in seconds)
             cv.Optional(CONF_VCSEC_POLL_INTERVAL, default=10): cv.int_range(min=5, max=300),
@@ -381,7 +382,7 @@ async def create_number(var, definition, config):
     # Handle dynamic max value from config
     max_val = definition["max"]
     if max_val == "config":
-        max_val = config.get(CONF_CHARGING_AMPS_MAX, 32)
+        max_val = config.get(CONF_CHARGING_AMPS_MAX, DEFAULT_CHARGING_AMPS_MAX)
     
     num_config = {
         CONF_ID: cv.declare_id(definition["class"])(f"tesla_{definition['id']}_number"),

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -48,6 +48,7 @@ void TeslaBLEVehicle::setup() {
   ESP_LOGCONFIG(TAG, "Setting up TeslaBLEVehicle");
   initialize_ble_uuids();
   initialize_managers();
+  restore_charging_amps_max_();
   configure_pending_sensors();
 
   if (vin_.empty()) {
@@ -243,7 +244,8 @@ void TeslaBLEVehicle::dump_config() {
   ESP_LOGCONFIG(TAG, "  VIN: %s", vin_.empty() ? "Not set" : vin_.c_str());
   ESP_LOGCONFIG(TAG, "  Role: %s", role_.c_str());
   ESP_LOGCONFIG(TAG, "  Max Charging Amps: %d",
-                state_manager_ ? state_manager_->get_charging_amps_max() : 32);
+                state_manager_ ? state_manager_->get_charging_amps_max()
+                               : DEFAULT_CHARGING_AMPS_MAX);
   ESP_LOGCONFIG(TAG, "  Polling: VCSEC=%ums, Awake=%ums, Active=%ums",
                 vcsec_poll_interval_, poll_policy_.awake_interval_ms(),
                 poll_policy_.active_interval_ms());
@@ -287,6 +289,31 @@ void TeslaBLEVehicle::set_charging_amps_max(int amps_max) {
 
   if (state_manager_) {
     state_manager_->set_charging_amps_max(amps_max);
+  }
+}
+
+void TeslaBLEVehicle::restore_charging_amps_max_() {
+  if (!state_manager_) return;
+  auto pref = global_preferences->make_preference<int32_t>(charging_amps_max_pref_hash_());
+  int32_t stored = 0;
+  if (pref.load(&stored) && stored > 0 && stored <= 80) {
+    ESP_LOGI(TAG, "Restored charging amps max from NVS: %" PRId32 " A", stored);
+    state_manager_->set_charging_amps_max(stored);
+    return;
+  }
+  state_manager_->set_charging_amps_max(configured_charging_amps_max_);
+}
+
+uint32_t TeslaBLEVehicle::charging_amps_max_pref_hash_() const {
+  return fnv1_hash_extend(fnv1_hash("tesla_ble_vehicle.charging_amps_max"), vin_);
+}
+
+void TeslaBLEVehicle::save_charging_amps_max_(int max) {
+  if (max <= 0 || max > 80) return;
+  auto pref = global_preferences->make_preference<int32_t>(charging_amps_max_pref_hash_());
+  const int32_t value = max;
+  if (pref.save(&value)) {
+    ESP_LOGD(TAG, "Persisted charging amps max %d A", max);
   }
 }
 
@@ -959,9 +986,7 @@ void TeslaBLEVehicle::handle_connection_established() {
     poll_policy_.reset();
   }
 
-  // Reset charging amps max to configured value on each connection
   if (state_manager_) {
-    state_manager_->set_charging_amps_max(configured_charging_amps_max_);
     state_manager_->set_sensors_available(true);
   }
   this->status_clear_warning();

--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.h
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.h
@@ -17,6 +17,7 @@
 #include <esphome/components/climate/climate.h>
 #include <esphome/core/component.h>
 #include <esphome/core/automation.h>
+#include <esphome/core/preferences.h>
 
 #include "ble_adapter_impl.h"
 #include "polling_policy.h"
@@ -31,6 +32,7 @@ namespace tesla_ble_vehicle {
 namespace espbt = esphome::esp32_ble_tracker;
 
 static const char *const TAG = "tesla_ble_vehicle";
+constexpr int DEFAULT_CHARGING_AMPS_MAX = 32;
 
 // Tesla BLE service UUIDs
 static const char *const SERVICE_UUID = "00000211-b2d1-43f0-9b88-960cebf8b91e";
@@ -231,8 +233,12 @@ private:
     
     std::string last_rx_hex_;
 
-    // Configured max (stored before state_manager is initialized)
-    int configured_charging_amps_max_{32};
+    // Fallback until the vehicle reports its maximum.
+    int configured_charging_amps_max_{DEFAULT_CHARGING_AMPS_MAX};
+
+    uint32_t charging_amps_max_pref_hash_() const;
+    void restore_charging_amps_max_();
+    void save_charging_amps_max_(int max);
 
     // Command tracking
     void handle_command_result(TeslaBLE::OperationResult result);

--- a/components/tesla_ble_vehicle/vehicle_state_manager.cpp
+++ b/components/tesla_ble_vehicle/vehicle_state_manager.cpp
@@ -1,6 +1,9 @@
 #include "vehicle_state_manager.h"
 #include "state_text.h"
 #include "tesla_ble_vehicle.h"
+#ifdef USE_API
+#include <esphome/components/api/api_server.h>
+#endif
 #include <esphome/core/helpers.h>
 #include <cmath>
 #include <algorithm>
@@ -694,9 +697,23 @@ void VehicleStateManager::update_charging_amps_max(int32_t new_max) {
 
     charging_amps_max_ = new_max;
 
-    if (charging_amps_number_) {
-        ESP_LOGD(STATE_MANAGER_TAG, "Updated max charging amps to %" PRId32 " A", new_max);
+    if (parent_) {
+        parent_->save_charging_amps_max_(new_max);
     }
+
+    if (charging_amps_number_) {
+        charging_amps_number_->traits.set_max_value(static_cast<float>(new_max));
+#ifdef USE_API
+        if (api::global_api_server != nullptr) {
+            // ESPHome sends number traits only during API entity discovery.
+            ESP_LOGI(STATE_MANAGER_TAG, "Reconnecting API clients to refresh charging amps limit");
+            for (const auto &client : api::global_api_server->active_clients()) {
+                client->on_fatal_error();
+            }
+        }
+#endif
+    }
+    ESP_LOGI(STATE_MANAGER_TAG, "Updated max charging amps to %" PRId32 " A", new_max);
 }
 
 // =============================================================================

--- a/components/tesla_ble_vehicle/vehicle_state_manager.h
+++ b/components/tesla_ble_vehicle/vehicle_state_manager.h
@@ -59,7 +59,12 @@ public:
     void set_charging_switch(switch_::Switch* sw) { charging_switch_ = sw; }
     void set_sentry_mode_switch(switch_::Switch* sw) { sentry_mode_switch_ = sw; }
     void set_steering_wheel_heat_switch(switch_::Switch* sw) { steering_wheel_heat_switch_ = sw; }
-    void set_charging_amps_number(number::Number* number) { charging_amps_number_ = number; }
+    void set_charging_amps_number(number::Number* number) {
+        charging_amps_number_ = number;
+        if (number != nullptr && charging_amps_max_ > 0) {
+            number->traits.set_max_value(static_cast<float>(charging_amps_max_));
+        }
+    }
     void set_charging_limit_number(number::Number* number) { charging_limit_number_ = number; }
     
     // ==========================================================================
@@ -129,7 +134,13 @@ public:
     // ==========================================================================
     void update_charging_amps_max(int32_t new_max);
     int get_charging_amps_max() const { return charging_amps_max_; }
-    void set_charging_amps_max(int max) { charging_amps_max_ = max; }
+    void set_charging_amps_max(int max) {
+        if (max <= 0) return;
+        charging_amps_max_ = max;
+        if (charging_amps_number_) {
+            charging_amps_number_->traits.set_max_value(static_cast<float>(max));
+        }
+    }
     
     
 private:
@@ -166,7 +177,7 @@ private:
     // Internal state tracking
     // ==========================================================================
     bool is_charging_{false};
-    int charging_amps_max_{32};
+    int charging_amps_max_{0};
     
     // Climate state tracking
     float current_inside_temp_{NAN};

--- a/packages/client.yml
+++ b/packages/client.yml
@@ -8,7 +8,6 @@ tesla_ble_vehicle:
   id: tesla_ble_vehicle_id
   vin: $tesla_vin
   # update_interval is automatically set to match vcsec_poll_interval
-  charging_amps_max: $charging_amps_max
   role: DRIVER  # Options: DRIVER (all controls) or CHARGING_MANAGER (charging + basic controls only)
   
   # Polling intervals (in seconds) - adjust based on your battery life vs responsiveness needs

--- a/packages/client_defaults.yml
+++ b/packages/client_defaults.yml
@@ -1,7 +1,6 @@
 substitutions:
   ble_mac_address: !secret ble_mac_address
   tesla_vin: !secret tesla_vin
-  charging_amps_max: "32"
   # Polling interval defaults (can be overridden in the main config).
   vcsec_poll_interval: "10"
   infotainment_poll_interval_awake: "30"

--- a/packages/dashboard.yml
+++ b/packages/dashboard.yml
@@ -3,7 +3,6 @@
 substitutions:
   # Set by the Device Builder configuration to a branch, tag, or commit SHA.
   tesla_ble_ref: main
-  charging_amps_max: "32"
   vcsec_poll_interval: "10"
   infotainment_poll_interval_awake: "30"
   infotainment_poll_interval_active: "10"

--- a/tesla-ble.example.yml
+++ b/tesla-ble.example.yml
@@ -9,7 +9,6 @@ substitutions:
   tesla_ble_ref: main
   ble_mac_address: "A0:B1:C2:D3:E4:F5" # vehicle BLE MAC address
   tesla_vin: "5YJ30123456789ABC" # vehicle VIN
-  charging_amps_max: "32"
 
   # Polling intervals (in seconds) - customize based on your needs
   # Lower values = more responsive but higher battery drain

--- a/tests/dashboard_config.yml
+++ b/tests/dashboard_config.yml
@@ -4,7 +4,6 @@ substitutions:
   tesla_ble_ref: a38ccb337763c0921c853ee29b9da1c44f036469
   name: tesla-ble-dashboard-test
   friendly_name: Tesla BLE Dashboard Test
-  charging_amps_max: "32"
   ble_mac_address: !secret test_vehicle_ble_mac
   tesla_vin: !secret test_vehicle_vin
   ota_password: !secret test_ota_password


### PR DESCRIPTION
## Summary
- persist the vehicle-reported charging-amps maximum in VIN-scoped NVS
- restore it before ESPHome advertises number traits
- reconnect API clients when the vehicle reports a changed maximum so Home Assistant refreshes the number limit without an ESP reboot
- use the named 32A fallback only until the vehicle reports its maximum
- remove redundant charging-amps-max substitutions from dashboard and example YAML

## Verification
- make test
- make validate-dashboard-config
- make compile BOARD=m5stack-nanoc6