### PR TITLE
fix: publish initial VCSEC binary states

### DIFF
--- a/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
+++ b/components/tesla_ble_vehicle/tesla_ble_vehicle.cpp
@@ -986,9 +986,6 @@ void TeslaBLEVehicle::handle_connection_established() {
     poll_policy_.reset();
   }
 
-  if (state_manager_) {
-    state_manager_->set_sensors_available(true);
-  }
   this->status_clear_warning();
 }
 


### PR DESCRIPTION
## Summary
- let the first VCSEC response publish asleep and user-presence states
- avoid pre-marking false-valued binary sensors as initialized on BLE connection

## Verification
- make test
- make compile BOARD=m5stack-nanoc6