### PR TITLE
Fix: add captive portal to Device Builder package

### DIFF
--- a/packages/dashboard.yml
+++ b/packages/dashboard.yml
@@ -22,3 +22,6 @@ logger:
 ota:
   - platform: esphome
     password: $ota_password
+
+# Same as CLI builds (base.yml): makes the Wi-Fi fallback AP usable.
+captive_portal:

--- a/tests/dashboard_config.yml
+++ b/tests/dashboard_config.yml
@@ -23,3 +23,5 @@ api:
 wifi:
   ssid: !secret test_wifi_ssid
   password: !secret test_wifi_password
+  ap:
+    password: !secret test_wifi_hotspot_password

--- a/tests/secrets.yaml
+++ b/tests/secrets.yaml
@@ -5,3 +5,4 @@ test_vehicle_ble_mac: "A0:B1:C2:D3:E4:F5"
 test_vehicle_vin: "5YJ30123456789ABC" # mock VIN example from PROTOCOL.md
 test_wifi_ssid: "test-network"
 test_wifi_password: "test-password"
+test_wifi_hotspot_password: "12345678"


### PR DESCRIPTION
CLI builds include `captive_portal:` (via `base.yml`); Device Builder builds did not, leaving the fallback AP with no portal (validation warns about it).

## What changed
- `packages/dashboard.yml`: added `captive_portal:`.
- `tests/dashboard_config.yml` + `tests/secrets.yaml`: mirror the generated fallback AP (`ap:` + hotspot secret) so the dashboard fixture validates warning-free.

## Validation (esphome==2026.8.2, already pinned)
- `make validate-config` and `make validate-dashboard-config`: valid, zero warnings.