### PR TITLE
Chore: sync AtomS3 board config (internal status LED, button logging)

### DIFF
--- a/boards/m5stack-atoms3.yml
+++ b/boards/m5stack-atoms3.yml
@@ -28,12 +28,13 @@ light:
   - platform: status_led
     output: status_output
     name: "Status Led"
+    internal: true
     entity_category: diagnostic
 
-  #G35=RGB WS2812C-2020
+  #G35=RGB WS2812C-2020 (4x LEDs under the button)
   - platform: esp32_rmt_led_strip
     channel_colors: GRB
-    pin: 35
+    pin: GPIO35
     num_leds: 4
     chipset: ws2812
     id: led
@@ -53,3 +54,6 @@ binary_sensor:
         pullup: true
     filters:
       - delayed_off: 10ms
+    on_press:
+      then:
+        - logger.log: Button Pressed


### PR DESCRIPTION
Aligns `boards/m5stack-atoms3.yml` with the verified canonical AtomS3 setup shared across projects:

- `Status Led` is now `internal: true` (still blinks physically, no HA entity noise).
- Button gains `on_press` logging like the other boards.
- `pin: 35` normalized to `pin: GPIO35`, LED comment notes the 4x WS2812C-2020 array.

Verified against M5Stack docs / devices.esphome.io (GPIO35 LEDs, GPIO41 button, Grove G1/G2, 8MB S3FN8). All board configs + dashboard validate warning-free on 2026.8.2.