### PR TITLE
Chore: drop config values that restate ESPHome defaults

### DIFF
--- a/packages/board.yml
+++ b/packages/board.yml
@@ -2,8 +2,9 @@ esp32:
   board: $board
   variant: $variant
   flash_size: $flash_size
+  # framework type defaults to esp-idf (only the managed components list
+  # below needs the block to exist).
   framework:
-    type: esp-idf
     components:
       - name: tesla-ble
         source: https://github.com/yoziru/tesla-ble.git

--- a/packages/common.yml
+++ b/packages/common.yml
@@ -1,12 +1,10 @@
 sensor:
   - platform: wifi_signal
     name: "WiFi Signal"
-    update_interval: 60s
     icon: mdi:wifi
 
   - platform: uptime
     name: "Uptime"
-    update_interval: 60s
     icon: mdi:clock-outline
 
 binary_sensor:


### PR DESCRIPTION
Verified against the ESPHome 2026.8 docs; all removed values equal current defaults:

- `packages/board.yml`: dropped `framework: type: esp-idf` (default since 2026.1); the `framework:` block itself stays because it carries the non-default IDF managed-components list (tesla-ble library).
- `packages/common.yml`: dropped `update_interval: 60s` on WiFi-signal + Uptime (both default to 60s).

Kept on purpose (non-defaults, checked): BLE `interval: 150ms` + `continuous: false` with the WiFi-gated scan automation (single-core coexistence), `logger: level: INFO` (default is DEBUG).

All 3 board configs + dashboard validate warning-free on 2026.8.2.