### PR TITLE
Chore: drop redundant BLE poll interval

### DIFF
--- a/packages/client.yml
+++ b/packages/client.yml
@@ -23,7 +23,6 @@ sensor:
     ble_client_id: ble_tesla_id
     name: "BLE Signal"
     icon: mdi:bluetooth
-    update_interval: 60s
     entity_category: diagnostic
 
 switch:


### PR DESCRIPTION
- `packages/client.yml`: dropped `update_interval: 60s` on the BLE Signal sensor (`ble_client` sensors inherit the 60s polling default; docs example omits the key). Watch the entity after deploy - if its update cadence ever looks off, this line is the revert candidate. Project version untouched (release-managed: `2026.8.0`).

Board config + dashboard validate warning-free on 2026.8.2.