### PR TITLE
Chore: improv_serial onboarding + 802.11k/v roaming

### DIFF
--- a/packages/base.yml
+++ b/packages/base.yml
@@ -26,9 +26,15 @@ ota:
   - platform: esphome
     password: !secret ota_password
 
+# Serial provisioning for first-time onboarding
+improv_serial:
+
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  # 802.11k/v roaming assistance (inert on networks without k/v support)
+  enable_rrm: true
+  enable_btm: true
   # Enable fallback hotspot (captive portal) in case wifi connection fails
   ap:
     password: !secret wifi_hotspot_password


### PR DESCRIPTION
- `packages/base.yml`: added `improv_serial` (one-click Wi-Fi onboarding parity with the other ESP32 projects) and `enable_rrm`/`enable_btm` (802.11k/v roaming assistance, inert on networks without k/v support) - same pair m5/zehnder already carry.

Watch after deploy: Wi-Fi roam behavior on mesh networks; both additions are trivially revertible. Flash fit on the 96.9%-full NanoC6 is proven by CI compile.

All 3 board configs + dashboard validate warning-free on 2026.8.2.