### PR TITLE
Fix: package-supplied fallback AP so captive portal never warns

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ api:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  ap:
+    password: !secret wifi_hotspot_password
 ```
 
 Secret names are local to each user's dashboard. If yours differ, keep `ble_mac_address` and `tesla_vin` on the left and change only the names after `!secret`.

--- a/packages/dashboard.yml
+++ b/packages/dashboard.yml
@@ -25,3 +25,10 @@ ota:
 
 # Same as CLI builds (base.yml): makes the Wi-Fi fallback AP usable.
 captive_portal:
+
+wifi:
+  # Device Builder owns ssid/password; the package only ensures the fallback
+  # AP exists so captive_portal has something to serve on (otherwise config
+  # validation warns "no WiFi AP is configured"). Open hotspot named after
+  # the device - set wifi.ap.password in the device YAML to secure it.
+  ap: {}


### PR DESCRIPTION
Fixes `WARNING Captive portal is enabled but no WiFi AP is configured` for Device Builder devices whose local config has no `wifi.ap` (the dashboard package brings `captive_portal:` but deliberately excludes Wi-Fi).

- `packages/dashboard.yml`: added `wifi: ap: {}` (docs' simple AP config: open hotspot named after the device, only comes up after 90s without home Wi-Fi). Deep-merges with the device's `ssid`/`password`; a device-level `wifi.ap.password` overrides it to a secured AP. Proven: an ap-less device config now validates with zero warnings.
- `README.md`: device example gains `ap: password: !secret wifi_hotspot_password` (that secret already exists in `secrets.yaml.example`).